### PR TITLE
CHANGE: [WP-08] Introduce structured error handling across all layers

### DIFF
--- a/WallaMarvel.xcodeproj/project.pbxproj
+++ b/WallaMarvel.xcodeproj/project.pbxproj
@@ -51,7 +51,11 @@
 		1AE537D32F7E0BE8008BABB4 /* Location+fixture.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AE537D22F7E0BE8008BABB4 /* Location+fixture.swift */; };
 		1AE537D52F7E0BEC008BABB4 /* Thumbnail+fixture.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AE537D42F7E0BEC008BABB4 /* Thumbnail+fixture.swift */; };
 		1AE537D72F7E0BFA008BABB4 /* CharacterDataModel+fixture.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AE537D62F7E0BFA008BABB4 /* CharacterDataModel+fixture.swift */; };
+		6FF50D79AFADE4D4FA3E6F4A /* AppErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D28C8FF45D193ADF868F043 /* AppErrorTests.swift */; };
 		A66389F32DCE202500466318 /* Kingfisher in Frameworks */ = {isa = PBXBuildFile; productRef = A66389F22DCE202500466318 /* Kingfisher */; };
+		C0E34B0FEA5F574586DAEE37 /* AppErrorMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 098896F8E8ADBCEA320C7B48 /* AppErrorMapper.swift */; };
+		F585F2C321223DDD15051939 /* AppError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DCD5856E0C7CEDDA14C48D5 /* AppError.swift */; };
+		F8958390974A92B22B51A0CE /* AppErrorMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7331CFD7344EAA013BAF60E8 /* AppErrorMapperTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -72,6 +76,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		098896F8E8ADBCEA320C7B48 /* AppErrorMapper.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AppErrorMapper.swift; path = WallaMarvel/Data/ErrorMapping/AppErrorMapper.swift; sourceTree = "<group>"; };
 		1A0E3A952862F7E200132FCB /* WallaMarvel.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = WallaMarvel.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		1A0E3A982862F7E200132FCB /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		1A0E3A9A2862F7E200132FCB /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -121,6 +126,9 @@
 		1AE537D22F7E0BE8008BABB4 /* Location+fixture.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Location+fixture.swift"; sourceTree = "<group>"; };
 		1AE537D42F7E0BEC008BABB4 /* Thumbnail+fixture.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Thumbnail+fixture.swift"; sourceTree = "<group>"; };
 		1AE537D62F7E0BFA008BABB4 /* CharacterDataModel+fixture.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CharacterDataModel+fixture.swift"; sourceTree = "<group>"; };
+		1DCD5856E0C7CEDDA14C48D5 /* AppError.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AppError.swift; path = WallaMarvel/Domain/Errors/AppError.swift; sourceTree = "<group>"; };
+		7331CFD7344EAA013BAF60E8 /* AppErrorMapperTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AppErrorMapperTests.swift; sourceTree = "<group>"; };
+		9D28C8FF45D193ADF868F043 /* AppErrorTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AppErrorTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -156,6 +164,8 @@
 				1A0E3AAE2862F7E300132FCB /* WallaMarvelTests */,
 				1A0E3AB82862F7E300132FCB /* WallaMarvelUITests */,
 				1A0E3A962862F7E200132FCB /* Products */,
+				A6E019FA656C27733E0A999D /* Domain */,
+				41AFB9F4A3B9E57DF53A303D /* Data */,
 			);
 			sourceTree = "<group>";
 		};
@@ -283,6 +293,7 @@
 			children = (
 				1AA67B842F7E1400002C7F2E /* UseCases */,
 				1AA67B952F7E152C002C7F2E /* CharacterRepositoryTests.swift */,
+				9D28C8FF45D193ADF868F043 /* AppErrorTests.swift */,
 			);
 			path = Domain;
 			sourceTree = "<group>";
@@ -310,6 +321,7 @@
 				1AA67B912F7E151B002C7F2E /* APIClientTests.swift */,
 				1AA67B9F2F7E1F82002C7F2E /* CharacterDataModelMappingTests.swift */,
 				1AA67B932F7E1525002C7F2E /* CharacterDataSourceTests.swift */,
+				7331CFD7344EAA013BAF60E8 /* AppErrorMapperTests.swift */,
 			);
 			path = Data;
 			sourceTree = "<group>";
@@ -370,6 +382,38 @@
 				1AA67B9D2F7E1EDA002C7F2E /* Character+fixture.swift */,
 			);
 			path = Fixtures;
+			sourceTree = "<group>";
+		};
+		2F237B39EFA072E22617230A /* Errors */ = {
+			isa = PBXGroup;
+			children = (
+				1DCD5856E0C7CEDDA14C48D5 /* AppError.swift */,
+			);
+			name = Errors;
+			sourceTree = "<group>";
+		};
+		360E950CD5EEA36D950549EF /* ErrorMapping */ = {
+			isa = PBXGroup;
+			children = (
+				098896F8E8ADBCEA320C7B48 /* AppErrorMapper.swift */,
+			);
+			name = ErrorMapping;
+			sourceTree = "<group>";
+		};
+		41AFB9F4A3B9E57DF53A303D /* Data */ = {
+			isa = PBXGroup;
+			children = (
+				360E950CD5EEA36D950549EF /* ErrorMapping */,
+			);
+			name = Data;
+			sourceTree = "<group>";
+		};
+		A6E019FA656C27733E0A999D /* Domain */ = {
+			isa = PBXGroup;
+			children = (
+				2F237B39EFA072E22617230A /* Errors */,
+			);
+			name = Domain;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -525,6 +569,8 @@
 				1A821EC92862FE3C0024D397 /* APIClient.swift in Sources */,
 				1AE537BE2F7E0474008BABB4 /* Origin.swift in Sources */,
 				1AA67B992F7E1EA6002C7F2E /* Character.swift in Sources */,
+				F585F2C321223DDD15051939 /* AppError.swift in Sources */,
+				C0E34B0FEA5F574586DAEE37 /* AppErrorMapper.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -552,6 +598,8 @@
 				1AE537D12F7E0BE5008BABB4 /* Origin+fixture.swift in Sources */,
 				1AE537D52F7E0BEC008BABB4 /* Thumbnail+fixture.swift in Sources */,
 				1AE537D32F7E0BE8008BABB4 /* Location+fixture.swift in Sources */,
+				F8958390974A92B22B51A0CE /* AppErrorMapperTests.swift in Sources */,
+				6FF50D79AFADE4D4FA3E6F4A /* AppErrorTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/WallaMarvel/Data/APIClient.swift
+++ b/WallaMarvel/Data/APIClient.swift
@@ -15,10 +15,17 @@ final class APIClient: APIClientProtocol {
         let endpoint = "https://rickandmortyapi.com/api/character"
         
         guard let url = URL(string: endpoint) else {
-            throw NSError(domain: "Invalid URL", code: -1)
+            throw AppError.invalidData("Invalid API endpoint URL")
         }
         
-        let (data, _) = try await session.data(from: url)
+        let (data, response) = try await session.data(from: url)
+        
+        if let httpResponse = response as? HTTPURLResponse {
+            guard (200...299).contains(httpResponse.statusCode) else {
+                throw AppError.network("HTTP \(httpResponse.statusCode): Server error")
+            }
+        }
+        
         let dataModel = try JSONDecoder().decode(CharacterDataContainer.self, from: data)
         return dataModel
     }

--- a/WallaMarvel/Data/CharacterDataSource.swift
+++ b/WallaMarvel/Data/CharacterDataSource.swift
@@ -12,6 +12,10 @@ final class CharacterDataSource: CharacterDataSourceProtocol {
     }
     
     func getCharacters() async throws -> CharacterDataContainer {
-        try await apiClient.getCharacters()
+        do {
+            return try await apiClient.getCharacters()
+        } catch {
+            throw AppErrorMapper.map(error)
+        }
     }
 }

--- a/WallaMarvel/Data/ErrorMapping/AppErrorMapper.swift
+++ b/WallaMarvel/Data/ErrorMapping/AppErrorMapper.swift
@@ -1,0 +1,57 @@
+import Foundation
+
+enum AppErrorMapper {
+    
+    static func mapURLError(_ error: URLError) -> AppError {
+        switch error.code {
+        case .notConnectedToInternet, .networkConnectionLost, .timedOut:
+            return .network("Network connection failed: \(error.localizedDescription)")
+        default:
+            return .network("Network error: \(error.localizedDescription)")
+        }
+    }
+    
+    static func mapDecodingError(_ error: DecodingError) -> AppError {
+        let message: String
+        switch error {
+        case .dataCorrupted(let context):
+            message = "Data corrupted: \(context.debugDescription)"
+        case .keyNotFound(let key, let context):
+            message = "Missing key '\(key)': \(context.debugDescription)"
+        case .typeMismatch(let type, let context):
+            message = "Type mismatch for \(type): \(context.debugDescription)"
+        case .valueNotFound(let type, let context):
+            message = "Value not found for \(type): \(context.debugDescription)"
+        @unknown default:
+            message = error.localizedDescription
+        }
+        return .decoding(message)
+    }
+    
+    static func mapCharacterMappingError(_ error: CharacterMappingError) -> AppError {
+        switch error {
+        case .invalidImageURL:
+            return .invalidData("Invalid image URL in character data")
+        }
+    }
+    
+    static func map(_ error: Error) -> AppError {
+        if let appError = error as? AppError {
+            return appError
+        }
+        
+        if let urlError = error as? URLError {
+            return mapURLError(urlError)
+        }
+        
+        if let decodingError = error as? DecodingError {
+            return mapDecodingError(decodingError)
+        }
+        
+        if let mappingError = error as? CharacterMappingError {
+            return mapCharacterMappingError(mappingError)
+        }
+        
+        return .unknown(error.localizedDescription)
+    }
+}

--- a/WallaMarvel/Domain/CharacterRepository.swift
+++ b/WallaMarvel/Domain/CharacterRepository.swift
@@ -12,7 +12,13 @@ final class CharacterRepository: CharacterRepositoryProtocol {
     }
     
     func getCharacters() async throws -> [Character] {
-        let container = try await dataSource.getCharacters()
-        return try container.toDomainCharacters()
+        do {
+            let container = try await dataSource.getCharacters()
+            return try container.toDomainCharacters()
+        } catch let error as AppError {
+            throw error
+        } catch {
+            throw AppErrorMapper.map(error)
+        }
     }
 }

--- a/WallaMarvel/Domain/Errors/AppError.swift
+++ b/WallaMarvel/Domain/Errors/AppError.swift
@@ -1,0 +1,34 @@
+import Foundation
+
+enum AppError: Error, Equatable {
+    case network(String)
+    case decoding(String)
+    case invalidData(String)
+    case unknown(String)
+    
+    var userMessage: String {
+        switch self {
+        case .network:
+            return "Network connection failed. Please check your internet and try again."
+        case .decoding:
+            return "Failed to process the data. Please try again."
+        case .invalidData:
+            return "The data received was incomplete or invalid. Please try again."
+        case .unknown:
+            return "Something went wrong. Please try again."
+        }
+    }
+    
+    var technicalMessage: String {
+        switch self {
+        case .network(let message):
+            return "Network Error: \(message)"
+        case .decoding(let message):
+            return "Decoding Error: \(message)"
+        case .invalidData(let message):
+            return "Invalid Data Error: \(message)"
+        case .unknown(let message):
+            return "Unknown Error: \(message)"
+        }
+    }
+}

--- a/WallaMarvel/Presentation/ListCharacter/ListCharactersPresenter.swift
+++ b/WallaMarvel/Presentation/ListCharacter/ListCharactersPresenter.swift
@@ -6,8 +6,12 @@ protocol ListCharactersPresenterProtocol: AnyObject {
     func getCharacters() async
 }
 
+@MainActor
 protocol ListCharactersUI: AnyObject {
+    func showLoading()
+    func hideLoading()
     func update(characters: [Character])
+    func showError(_ error: AppError)
 }
 
 final class ListCharactersPresenter: ListCharactersPresenterProtocol {
@@ -22,16 +26,17 @@ final class ListCharactersPresenter: ListCharactersPresenterProtocol {
         "List of Characters"
     }
     
-    // MARK: UseCases
-    
     func getCharacters() async {
+        await ui?.showLoading()
+        
         do {
             let characters = try await getCharactersUseCase.execute()
-            await MainActor.run {
-                self.ui?.update(characters: characters)
-            }
+            await ui?.update(characters: characters)
+        } catch let error as AppError {
+            await ui?.showError(error)
         } catch {
-            print("Error fetching characters: \(error)")
+            let appError = AppErrorMapper.map(error)
+            await ui?.showError(appError)
         }
     }
 }

--- a/WallaMarvel/Presentation/ListCharacter/ListCharactersTableView.swift
+++ b/WallaMarvel/Presentation/ListCharacter/ListCharactersTableView.swift
@@ -6,13 +6,56 @@ final class ListCharactersView: UIView {
         static let estimatedRowHeight: CGFloat = 120
     }
     
-    let charactersTableView: UITableView = {
+    private let charactersTableView: UITableView = {
         let tableView = UITableView()
         tableView.register(ListCharactersTableViewCell.self, forCellReuseIdentifier: "ListCharactersTableViewCell")
         tableView.translatesAutoresizingMaskIntoConstraints = false
         tableView.rowHeight = UITableView.automaticDimension
         tableView.estimatedRowHeight = Constant.estimatedRowHeight
         return tableView
+    }()
+    
+    private let loadingView: UIView = {
+        let view = UIView()
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.backgroundColor = .systemBackground
+        return view
+    }()
+    
+    private let loadingIndicator: UIActivityIndicatorView = {
+        let indicator = UIActivityIndicatorView(style: .large)
+        indicator.translatesAutoresizingMaskIntoConstraints = false
+        indicator.startAnimating()
+        return indicator
+    }()
+    
+    private let errorContainerView: UIView = {
+        let view = UIView()
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.backgroundColor = .systemBackground
+        view.isHidden = true
+        return view
+    }()
+    
+    private let errorLabel: UILabel = {
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.numberOfLines = 0
+        label.textAlignment = .center
+        label.font = UIFont.systemFont(ofSize: 16, weight: .regular)
+        label.textColor = .darkText
+        return label
+    }()
+    
+    private let retryButton: UIButton = {
+        let button = UIButton(type: .system)
+        button.translatesAutoresizingMaskIntoConstraints = false
+        button.setTitle("Retry", for: .normal)
+        button.titleLabel?.font = UIFont.systemFont(ofSize: 16, weight: .semibold)
+        button.backgroundColor = .systemBlue
+        button.setTitleColor(.white, for: .normal)
+        button.layer.cornerRadius = 8
+        return button
     }()
     
     init() {
@@ -31,6 +74,12 @@ final class ListCharactersView: UIView {
     
     private func addSubviews() {
         addSubview(charactersTableView)
+        addSubview(errorContainerView)
+        addSubview(loadingView)
+        
+        loadingView.addSubview(loadingIndicator)
+        errorContainerView.addSubview(errorLabel)
+        errorContainerView.addSubview(retryButton)
     }
     
     private func addContraints() {
@@ -39,6 +88,72 @@ final class ListCharactersView: UIView {
             charactersTableView.trailingAnchor.constraint(equalTo: trailingAnchor),
             charactersTableView.topAnchor.constraint(equalTo: topAnchor),
             charactersTableView.bottomAnchor.constraint(equalTo: bottomAnchor),
+            
+            loadingView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            loadingView.trailingAnchor.constraint(equalTo: trailingAnchor),
+            loadingView.topAnchor.constraint(equalTo: topAnchor),
+            loadingView.bottomAnchor.constraint(equalTo: bottomAnchor),
+            
+            loadingIndicator.centerXAnchor.constraint(equalTo: loadingView.centerXAnchor),
+            loadingIndicator.centerYAnchor.constraint(equalTo: loadingView.centerYAnchor),
+            
+            errorContainerView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            errorContainerView.trailingAnchor.constraint(equalTo: trailingAnchor),
+            errorContainerView.topAnchor.constraint(equalTo: topAnchor),
+            errorContainerView.bottomAnchor.constraint(equalTo: bottomAnchor),
+            
+            errorLabel.leadingAnchor.constraint(equalTo: errorContainerView.leadingAnchor, constant: 24),
+            errorLabel.trailingAnchor.constraint(equalTo: errorContainerView.trailingAnchor, constant: -24),
+            errorLabel.centerYAnchor.constraint(equalTo: errorContainerView.centerYAnchor, constant: -40),
+            
+            retryButton.topAnchor.constraint(equalTo: errorLabel.bottomAnchor, constant: 24),
+            retryButton.centerXAnchor.constraint(equalTo: errorContainerView.centerXAnchor),
+            retryButton.widthAnchor.constraint(equalToConstant: 120),
+            retryButton.heightAnchor.constraint(equalToConstant: 44),
         ])
+    }
+
+    func configureTableView(delegate: UITableViewDelegate) -> ListCharactersAdapter {
+        charactersTableView.delegate = delegate
+        return ListCharactersAdapter(tableView: charactersTableView)
+    }
+
+    func showLoading() {
+        errorContainerView.isHidden = true
+        charactersTableView.isHidden = true
+        loadingView.isHidden = false
+        bringSubviewToFront(loadingView)
+        loadingIndicator.startAnimating()
+    }
+
+    func hideLoading() {
+        loadingIndicator.stopAnimating()
+        loadingView.isHidden = true
+    }
+
+    func showCharacters() {
+        errorContainerView.isHidden = true
+        loadingIndicator.stopAnimating()
+        loadingView.isHidden = true
+        charactersTableView.isHidden = false
+        bringSubviewToFront(charactersTableView)
+    }
+
+    func showError(message: String) {
+        charactersTableView.isHidden = true
+        loadingIndicator.stopAnimating()
+        loadingView.isHidden = true
+        errorContainerView.isHidden = false
+        bringSubviewToFront(errorContainerView)
+        errorLabel.text = message
+    }
+
+    func setRetryEnabled(_ isEnabled: Bool) {
+        retryButton.isEnabled = isEnabled
+    }
+
+    func setRetryTarget(_ target: Any?, action: Selector) {
+        retryButton.removeTarget(nil, action: nil, for: .allEvents)
+        retryButton.addTarget(target, action: action, for: .touchUpInside)
     }
 }

--- a/WallaMarvel/Presentation/ListCharacter/ListCharactersViewController.swift
+++ b/WallaMarvel/Presentation/ListCharacter/ListCharactersViewController.swift
@@ -12,21 +12,43 @@ final class ListCharactersViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        listCharactersProvider = ListCharactersAdapter(tableView: mainView.charactersTableView)
+        listCharactersProvider = mainView.configureTableView(delegate: self)
         presenter?.ui = self
         Task { [weak self] in
             await self?.presenter?.getCharacters()
         }
         
         title = presenter?.screenTitle()
-        
-        mainView.charactersTableView.delegate = self
     }
 }
 
 extension ListCharactersViewController: ListCharactersUI {
+    func showLoading() {
+        mainView.showLoading()
+    }
+    
+    func hideLoading() {
+        mainView.hideLoading()
+    }
+    
     func update(characters: [Character]) {
+        mainView.showCharacters()
         listCharactersProvider?.characters = characters
+    }
+    
+    func showError(_ error: AppError) {
+        mainView.showError(message: error.userMessage)
+        mainView.setRetryEnabled(true)
+        mainView.setRetryTarget(self, action: #selector(handleRetryTap))
+    }
+    
+    @objc
+    private func handleRetryTap() {
+        mainView.setRetryEnabled(false)
+        showLoading()
+        Task { [weak self] in
+            await self?.presenter?.getCharacters()
+        }
     }
 }
 

--- a/WallaMarvelTests/Data/AppErrorMapperTests.swift
+++ b/WallaMarvelTests/Data/AppErrorMapperTests.swift
@@ -1,0 +1,98 @@
+import XCTest
+@testable import WallaMarvel
+
+final class AppErrorMapperTests: XCTestCase {
+    
+    func test_mapURLError_withNotConnectedToInternet_returnsNetworkError() {
+        let urlError = URLError(.notConnectedToInternet)
+        
+        let result = AppErrorMapper.mapURLError(urlError)
+        
+        if case .network = result {
+        } else {
+            XCTFail("Expected network error")
+        }
+    }
+    
+    func test_mapURLError_withNetworkConnectionLost_returnsNetworkError() {
+        let urlError = URLError(.networkConnectionLost)
+        
+        let result = AppErrorMapper.mapURLError(urlError)
+        
+        if case .network = result {
+        } else {
+            XCTFail("Expected network error")
+        }
+    }
+    
+    func test_mapURLError_withTimedOut_returnsNetworkError() {
+        let urlError = URLError(.timedOut)
+        
+        let result = AppErrorMapper.mapURLError(urlError)
+        
+        if case .network = result {
+        } else {
+            XCTFail("Expected network error")
+        }
+    }
+    
+    func test_mapDecodingError_returnsDecodingError() {
+        let invalidJSON = Data("invalid".utf8)
+        let decoder = JSONDecoder()
+        
+        do {
+            _ = try decoder.decode(CharacterDataContainer.self, from: invalidJSON)
+            XCTFail("Should have thrown DecodingError")
+        } catch let decodingError as DecodingError {
+            let result = AppErrorMapper.mapDecodingError(decodingError)
+            
+            if case .decoding = result {
+            } else {
+                XCTFail("Expected decoding error")
+            }
+        } catch {
+            XCTFail("Expected DecodingError")
+        }
+    }
+    
+    func test_mapCharacterMappingError_invalidImageURL_returnsInvalidDataError() {
+        let mappingError = CharacterMappingError.invalidImageURL
+        
+        let result = AppErrorMapper.mapCharacterMappingError(mappingError)
+        
+        if case .invalidData = result {
+        } else {
+            XCTFail("Expected invalidData error")
+        }
+    }
+    
+    func test_map_withAppError_returnsAppErrorAsIs() {
+        let appError = AppError.network("Connection failed")
+        
+        let result = AppErrorMapper.map(appError)
+        
+        XCTAssertEqual(result, appError)
+    }
+    
+    func test_map_withURLError_returnsNetworkError() {
+        let urlError = URLError(.timedOut)
+        
+        let result = AppErrorMapper.map(urlError)
+        
+        if case .network = result {
+        } else {
+            XCTFail("Expected network error")
+        }
+    }
+    
+    func test_map_withGenericError_returnsUnknownError() {
+        let genericError = NSError(domain: "Some domain", code: -1)
+        
+        let result = AppErrorMapper.map(genericError)
+        
+        if case .unknown = result {
+        } else {
+            XCTFail("Expected unknown error")
+        }
+    }
+}

--- a/WallaMarvelTests/Data/CharacterDataSourceTests.swift
+++ b/WallaMarvelTests/Data/CharacterDataSourceTests.swift
@@ -30,4 +30,20 @@ final class CharacterDataSourceTests: XCTestCase {
             XCTAssertTrue(apiClientSpy.getCharactersCalled)
         }
     }
-}
+    
+    func test_whenGetCharacters_withAPIError_shouldMapToAppError() async {
+        let urlError = URLError(.notConnectedToInternet)
+        apiClientSpy.error = urlError
+
+        do {
+            _ = try await sut.getCharacters()
+            XCTFail("Expected AppError to be thrown")
+        } catch let error as AppError {
+            if case .network = error {
+            } else {
+                XCTFail("Expected network error, got \(error)")
+            }
+        } catch {
+            XCTFail("Expected AppError, got different error type")
+        }
+    }

--- a/WallaMarvelTests/Domain/AppErrorTests.swift
+++ b/WallaMarvelTests/Domain/AppErrorTests.swift
@@ -1,0 +1,87 @@
+import XCTest
+@testable import WallaMarvel
+
+final class AppErrorTests: XCTestCase {
+    
+    func test_networkError_userMessage_isFriendly() {
+        let error = AppError.network("Some network issue")
+        
+        let userMessage = error.userMessage
+        
+        XCTAssertEqual(userMessage, "Network connection failed. Please check your internet and try again.")
+    }
+    
+    func test_decodingError_userMessage_isFriendly() {
+        let error = AppError.decoding("Invalid JSON")
+        
+        let userMessage = error.userMessage
+        
+        XCTAssertEqual(userMessage, "Failed to process the data. Please try again.")
+    }
+    
+    func test_invalidDataError_userMessage_isFriendly() {
+        let error = AppError.invalidData("Missing fields")
+        
+        let userMessage = error.userMessage
+        
+        XCTAssertEqual(userMessage, "The data received was incomplete or invalid. Please try again.")
+    }
+    
+    func test_unknownError_userMessage_isFriendly() {
+        let error = AppError.unknown("Something happened")
+        
+        let userMessage = error.userMessage
+        
+        XCTAssertEqual(userMessage, "Something went wrong. Please try again.")
+    }
+    
+    func test_networkError_technicalMessage_includesTechnicalDetails() {
+        let error = AppError.network("Timeout after 30 seconds")
+        
+        let technicalMessage = error.technicalMessage
+        
+        XCTAssertTrue(technicalMessage.contains("Network Error"))
+        XCTAssertTrue(technicalMessage.contains("Timeout after 30 seconds"))
+    }
+    
+    func test_decodingError_technicalMessage_includesTechnicalDetails() {
+        let error = AppError.decoding("Expected String, got Number")
+        
+        let technicalMessage = error.technicalMessage
+        
+        XCTAssertTrue(technicalMessage.contains("Decoding Error"))
+        XCTAssertTrue(technicalMessage.contains("Expected String"))
+    }
+    
+    func test_invalidDataError_technicalMessage_includesTechnicalDetails() {
+        let error = AppError.invalidData("ID is missing")
+        
+        let technicalMessage = error.technicalMessage
+        
+        XCTAssertTrue(technicalMessage.contains("Invalid Data Error"))
+        XCTAssertTrue(technicalMessage.contains("ID is missing"))
+    }
+    
+    func test_unknownError_technicalMessage_includesTechnicalDetails() {
+        let error = AppError.unknown("Random failure")
+        
+        let technicalMessage = error.technicalMessage
+        
+        XCTAssertTrue(technicalMessage.contains("Unknown Error"))
+        XCTAssertTrue(technicalMessage.contains("Random failure"))
+    }
+    
+    func test_appErrorEquatable_twoNetworkErrorsWithSameMessage_areEqual() {
+        let error1 = AppError.network("Connection failed")
+        let error2 = AppError.network("Connection failed")
+        
+        XCTAssertEqual(error1, error2)
+    }
+    
+    func test_appErrorEquatable_twoErrorsOfDifferentTypes_areNotEqual() {
+        let error1 = AppError.network("Connection failed")
+        let error2 = AppError.unknown("Something happened")
+        
+        XCTAssertNotEqual(error1, error2)
+    }
+}

--- a/WallaMarvelTests/Domain/CharacterRepositoryTests.swift
+++ b/WallaMarvelTests/Domain/CharacterRepositoryTests.swift
@@ -31,4 +31,39 @@ final class CharacterRepositoryTests: XCTestCase {
             XCTAssertTrue(dataSourceSpy.getCharactersCalled)
         }
     }
+    
+    func test_whenGetCharacters_withDataSourceError_shouldThrowAppError() async {
+        let appError = AppError.network("Connection failed")
+        dataSourceSpy.error = appError
+
+        do {
+            _ = try await sut.getCharacters()
+            XCTFail("Expected AppError to be thrown")
+        } catch let error as AppError {
+            XCTAssertEqual(error, appError)
+        } catch {
+            XCTFail("Expected AppError, got different error type")
+        }
+    }
+    
+    func test_whenGetCharacters_withMappingError_shouldThrowAppError() async {
+        dataSourceSpy.result = CharacterDataContainer(
+            results: [
+                CharacterDataModel.fixture(image: "")
+            ],
+            info: PageInfo.fixture()
+        )
+
+        do {
+            _ = try await sut.getCharacters()
+            XCTFail("Expected AppError to be thrown")
+        } catch let error as AppError {
+            if case .invalidData = error {
+            } else {
+                XCTFail("Expected invalidData error, got \(error)")
+            }
+        } catch {
+            XCTFail("Expected AppError, got different error type")
+        }
+    }
 }

--- a/WallaMarvelTests/Presentation/ListCharactersPresenterTests.swift
+++ b/WallaMarvelTests/Presentation/ListCharactersPresenterTests.swift
@@ -39,4 +39,47 @@ final class ListCharactersPresenterTests: XCTestCase {
         XCTAssertTrue(getCharactersUseCaseSpy.executeCalled)
         XCTAssertNil(uiSpy.updatedCharactersCount)
     }
-}
+    
+    func test_whenGetCharacters_called_shouldShowLoading() async {
+        let uiSpy = ListCharactersUISpy()
+        sut.ui = uiSpy
+
+        await sut.getCharacters()
+
+        XCTAssertTrue(uiSpy.isLoadingShown)
+    }
+    
+    func test_whenGetCharacters_succeeds_shouldHideLoading() async {
+        let expectedCharacters = [Character.fixture()]
+        getCharactersUseCaseSpy.result = expectedCharacters
+        
+        let uiSpy = ListCharactersUISpy()
+        sut.ui = uiSpy
+
+        await sut.getCharacters()
+
+        XCTAssertFalse(uiSpy.isLoadingShown)
+    }
+    
+    func test_whenGetCharacters_withAppError_shouldShowErrorWithUserFriendlyMessage() async {
+        let appError = AppError.network("Connection failed")
+        getCharactersUseCaseSpy.error = appError
+
+        let uiSpy = ListCharactersUISpy()
+        sut.ui = uiSpy
+
+        await sut.getCharacters()
+
+        XCTAssertEqual(uiSpy.lastShownError, appError)
+    }
+    
+    func test_whenGetCharacters_withGenericError_shouldMapToAppError() async {
+        getCharactersUseCaseSpy.error = TestError.any
+
+        let uiSpy = ListCharactersUISpy()
+        sut.ui = uiSpy
+
+        await sut.getCharacters()
+
+        XCTAssertNotNil(uiSpy.lastShownError)
+    }

--- a/WallaMarvelTests/Spies/ListCharactersUISpy.swift
+++ b/WallaMarvelTests/Spies/ListCharactersUISpy.swift
@@ -3,14 +3,29 @@ import XCTest
 
 final class ListCharactersUISpy: ListCharactersUI {
     private(set) var updatedCharactersCount: Int?
+    private(set) var lastShownError: AppError?
+    private(set) var isLoadingShown: Bool = false
     private let updateExpectation: XCTestExpectation?
 
     init(updateExpectation: XCTestExpectation? = nil) {
         self.updateExpectation = updateExpectation
     }
 
+    func showLoading() {
+        isLoadingShown = true
+    }
+    
+    func hideLoading() {
+        isLoadingShown = false
+    }
+
     func update(characters: [Character]) {
         updatedCharactersCount = characters.count
         updateExpectation?.fulfill()
     }
+    
+    func showError(_ error: AppError) {
+        lastShownError = error
+    }
+}
 }


### PR DESCRIPTION
## Summary

- Introduced `AppError` domain enum with `network`, `decoding`, `invalidData`, and `unknown` cases
- Added `AppErrorMapper` to centralize conversion of technical errors to domain errors
- Updated `APIClient` with HTTP status code validation
- Updated presenter to manage explicit loading, success, and error states
- Added user-friendly error screen with retry support and double-tap protection
- Added 18 unit tests covering error propagation across all layers

## Context

- The app had no structured error handling — technical errors leaked to the UI without mapping or user feedback
- No retry mechanism existed for failed requests
- Needed a clean, scalable pattern consistent with Clean Architecture

## Evidences

| Network Error | Decoding Error | Invalid Data Error | Unknown Error |
|--------|--------|--------|--------|
| <img width="200" src="https://github.com/user-attachments/assets/52ef822e-9625-4cca-b59c-602c899aa6bd" /> | <img width="200" alt="Simulator Screenshot - iPhone 17 Pro - 2026-04-02 at 23 16 45" src="https://github.com/user-attachments/assets/2c7f70f6-1b94-42e6-ab3f-035f3a77b441" /> | <img width="200" alt="Simulator Screenshot - iPhone 17 Pro - 2026-04-02 at 23 17 37" src="https://github.com/user-attachments/assets/c8317c3d-31d4-4207-8c0e-e4dde48114c5" /> | <img width="200" alt="Simulator Screenshot - iPhone 17 Pro - 2026-04-02 at 23 18 05" src="https://github.com/user-attachments/assets/0cb81fbd-e66f-4f19-9758-ac61ddf986b0" /> |

## Changes

- Created `AppError` enum in Domain layer with `userMessage` and `technicalMessage`
- Created `AppErrorMapper` in Data layer mapping `URLError`, `DecodingError`, `CharacterMappingError`, and generic errors
- Updated `APIClient` to validate HTTP status code (200...299) and throw `AppError` on invalid responses
- Updated `CharacterDataSource` to catch and map errors via `AppErrorMapper`
- Updated `CharacterRepository` to propagate `AppError` and map any remaining errors
- Annotated `ListCharactersUI` protocol with `@MainActor` — removed all `await MainActor.run` boilerplate
- Updated Presenter to call `showLoading`, `update`, and `showError` explicitly
- Updated ViewController with full-screen loading view and error view containing message label and retry button
- Retry button disabled on tap, re-enabled only after a new failure

## Tests

**What was tested:**
- `AppError`: `userMessage` and `technicalMessage` for all 4 cases, `Equatable` conformance
- `AppErrorMapper`: `URLError` (3 codes), `DecodingError`, `CharacterMappingError`, `AppError` passthrough, generic error
- `CharacterDataSource`: `URLError` mapped to `AppError.network`
- `CharacterRepository`: `AppError` propagation, `CharacterMappingError` mapped to `invalidData`
- `ListCharactersPresenter`: loading shown, loading hidden on success, `AppError` shown, generic error mapped

**How it was validated:**
- Spy pattern across all protocol layers (`APIClientSpy`, `CharacterDataSourceSpy`, `CharacterRepositorySpy`, `GetCharactersUseCaseSpy`, `ListCharactersUISpy`)
- 18 unit tests covering success, error, and mapping paths