### PR TITLE
ADD: [WP-02] Add incremental pagination with retry and structured error handling

### DIFF
--- a/WallaMarvel.xcodeproj/project.pbxproj
+++ b/WallaMarvel.xcodeproj/project.pbxproj
@@ -25,6 +25,7 @@
 		1A821ED6286305590024D397 /* CharacterDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A821ED5286305590024D397 /* CharacterDataSource.swift */; };
 		1A821ED82863081A0024D397 /* CharacterRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A821ED72863081A0024D397 /* CharacterRepository.swift */; };
 		1A821EDA2863096C0024D397 /* ListCharactersPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A821ED92863096C0024D397 /* ListCharactersPresenter.swift */; };
+		1A86FC102F7F75B9000A34FE /* CharacterDataModelMappingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AA67B9F2F7E1F82002C7F2E /* CharacterDataModelMappingTests.swift */; };
 		1AA67B802F7E1186002C7F2E /* ListCharactersUISpy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AA67B7F2F7E1186002C7F2E /* ListCharactersUISpy.swift */; };
 		1AA67B822F7E13EF002C7F2E /* CharacterRepositorySpy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AA67B812F7E13EF002C7F2E /* CharacterRepositorySpy.swift */; };
 		1AA67B862F7E1407002C7F2E /* GetCharactersTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AA67B852F7E1407002C7F2E /* GetCharactersTests.swift */; };
@@ -586,6 +587,7 @@
 				1AA67B9E2F7E1EDA002C7F2E /* Character+fixture.swift in Sources */,
 				1AE537D72F7E0BFA008BABB4 /* CharacterDataModel+fixture.swift in Sources */,
 				1AE537CD2F7E0B6C008BABB4 /* CharacterDataContainer+fixture.swift in Sources */,
+				1A86FC102F7F75B9000A34FE /* CharacterDataModelMappingTests.swift in Sources */,
 				1AA67B822F7E13EF002C7F2E /* CharacterRepositorySpy.swift in Sources */,
 				1AE537CF2F7E0BE1008BABB4 /* PageInfo+fixture.swift in Sources */,
 				1AA67B942F7E1525002C7F2E /* CharacterDataSourceTests.swift in Sources */,
@@ -758,8 +760,10 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = FB627NQ75M;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = WallaMarvel/Info.plist;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
@@ -772,8 +776,9 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.wallapop.WallaMarvel;
+				PRODUCT_BUNDLE_IDENTIFIER = com.josealcidesjunior.WallaMarvel;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -785,8 +790,10 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = FB627NQ75M;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = WallaMarvel/Info.plist;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
@@ -799,8 +806,9 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.wallapop.WallaMarvel;
+				PRODUCT_BUNDLE_IDENTIFIER = com.josealcidesjunior.WallaMarvel;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/WallaMarvel/Data/APIClient.swift
+++ b/WallaMarvel/Data/APIClient.swift
@@ -1,32 +1,52 @@
 import Foundation
 
 protocol APIClientProtocol {
-    func getCharacters() async throws -> CharacterDataContainer
+    func getCharacters(page: Int) async throws -> CharacterDataContainer
 }
 
 final class APIClient: APIClientProtocol {
     private let session: URLSession
-    
-    init(session: URLSession = URLSession.shared) {
+    private let maxRetries: Int
+    private let retryDelay: UInt64
+
+    init(
+        session: URLSession = URLSession.shared,
+        maxRetries: Int = 3,
+        retryDelay: UInt64 = 1_000_000_000
+    ) {
         self.session = session
+        self.maxRetries = maxRetries
+        self.retryDelay = retryDelay
     }
-    
-    func getCharacters() async throws -> CharacterDataContainer {
-        let endpoint = "https://rickandmortyapi.com/api/character"
-        
-        guard let url = URL(string: endpoint) else {
+
+    func getCharacters(page: Int) async throws -> CharacterDataContainer {
+        var components = URLComponents(string: "https://rickandmortyapi.com/api/character")
+        components?.queryItems = [URLQueryItem(name: "page", value: String(page))]
+
+        guard let url = components?.url else {
             throw AppError.invalidData("Invalid API endpoint URL")
         }
-        
-        let (data, response) = try await session.data(from: url)
-        
-        if let httpResponse = response as? HTTPURLResponse {
-            guard (200...299).contains(httpResponse.statusCode) else {
-                throw AppError.network("HTTP \(httpResponse.statusCode): Server error")
+
+        var lastError: Error?
+        for attempt in 1...maxRetries {
+            do {
+                let (data, response) = try await session.data(from: url)
+
+                if let httpResponse = response as? HTTPURLResponse {
+                    guard (200...299).contains(httpResponse.statusCode) else {
+                        throw AppError.network("HTTP \(httpResponse.statusCode): Server error")
+                    }
+                }
+
+                return try JSONDecoder().decode(CharacterDataContainer.self, from: data)
+            } catch {
+                lastError = error
+                if attempt < maxRetries {
+                    try? await Task.sleep(nanoseconds: UInt64(attempt) * retryDelay)
+                }
             }
         }
-        
-        let dataModel = try JSONDecoder().decode(CharacterDataContainer.self, from: data)
-        return dataModel
+
+        throw lastError!
     }
 }

--- a/WallaMarvel/Data/CharacterDataSource.swift
+++ b/WallaMarvel/Data/CharacterDataSource.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 protocol CharacterDataSourceProtocol {
-    func getCharacters() async throws -> CharacterDataContainer
+    func getCharacters(page: Int) async throws -> CharacterDataContainer
 }
 
 final class CharacterDataSource: CharacterDataSourceProtocol {
@@ -11,9 +11,9 @@ final class CharacterDataSource: CharacterDataSourceProtocol {
         self.apiClient = apiClient
     }
     
-    func getCharacters() async throws -> CharacterDataContainer {
+    func getCharacters(page: Int) async throws -> CharacterDataContainer {
         do {
-            return try await apiClient.getCharacters()
+            return try await apiClient.getCharacters(page: page)
         } catch {
             throw AppErrorMapper.map(error)
         }

--- a/WallaMarvel/Domain/CharacterRepository.swift
+++ b/WallaMarvel/Domain/CharacterRepository.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 protocol CharacterRepositoryProtocol {
-    func getCharacters() async throws -> [Character]
+    func getCharacters(page: Int) async throws -> CharactersPage
 }
 
 final class CharacterRepository: CharacterRepositoryProtocol {
@@ -11,10 +11,11 @@ final class CharacterRepository: CharacterRepositoryProtocol {
         self.dataSource = dataSource
     }
     
-    func getCharacters() async throws -> [Character] {
+    func getCharacters(page: Int) async throws -> CharactersPage {
         do {
-            let container = try await dataSource.getCharacters()
-            return try container.toDomainCharacters()
+            let container = try await dataSource.getCharacters(page: page)
+            let characters = try container.toDomainCharacters()
+            return CharactersPage(characters: characters, hasNextPage: container.info.next != nil)
         } catch let error as AppError {
             throw error
         } catch {

--- a/WallaMarvel/Domain/Entities/Character.swift
+++ b/WallaMarvel/Domain/Entities/Character.swift
@@ -26,7 +26,9 @@ struct Character: Equatable {
         locationName: String,
         episodeCount: Int
     ) throws {
-        guard !imageURL.isEmpty, URL(string: imageURL) != nil else {
+        guard !imageURL.isEmpty,
+              let url = URL(string: imageURL),
+              url.scheme == "https" || url.scheme == "http" else {
             throw CharacterMappingError.invalidImageURL
         }
         
@@ -40,4 +42,9 @@ struct Character: Equatable {
         self.locationName = locationName
         self.episodeCount = episodeCount
     }
+}
+
+struct CharactersPage {
+    let characters: [Character]
+    let hasNextPage: Bool
 }

--- a/WallaMarvel/Domain/UseCases/GetCharacters.swift
+++ b/WallaMarvel/Domain/UseCases/GetCharacters.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 protocol GetCharactersUseCaseProtocol {
-    func execute() async throws -> [Character]
+    func execute(page: Int) async throws -> CharactersPage
 }
 
 struct GetCharacters: GetCharactersUseCaseProtocol {
@@ -11,7 +11,7 @@ struct GetCharacters: GetCharactersUseCaseProtocol {
         self.repository = repository
     }
     
-    func execute() async throws -> [Character] {
-        try await repository.getCharacters()
+    func execute(page: Int) async throws -> CharactersPage {
+        try await repository.getCharacters(page: page)
     }
 }

--- a/WallaMarvel/Presentation/ListCharacter/ListCharactersAdapter.swift
+++ b/WallaMarvel/Presentation/ListCharacter/ListCharactersAdapter.swift
@@ -2,33 +2,50 @@ import Foundation
 import UIKit
 
 final class ListCharactersAdapter: NSObject, UITableViewDataSource {
-    var characters: [Character] {
-        didSet {
-            DispatchQueue.main.async {
-                self.tableView.reloadData()
-            }
-        }
-    }
-    
+    private(set) var characters: [Character] = []
     private let tableView: UITableView
-    
+    private let paginationFooter: UIActivityIndicatorView = {
+        let indicator = UIActivityIndicatorView(style: .medium)
+        indicator.frame = CGRect(x: 0, y: 0, width: UIScreen.main.bounds.width, height: 52)
+        return indicator
+    }()
+
     init(tableView: UITableView, characters: [Character] = []) {
         self.tableView = tableView
         self.characters = characters
         super.init()
         self.tableView.dataSource = self
     }
-    
+
+    func setCharacters(_ newCharacters: [Character]) {
+        characters = newCharacters
+        tableView.reloadData()
+    }
+
+    func appendCharacters(_ newCharacters: [Character]) {
+        let startIndex = characters.count
+        characters.append(contentsOf: newCharacters)
+        let indexPaths = (startIndex..<characters.count).map { IndexPath(row: $0, section: 0) }
+        tableView.insertRows(at: indexPaths, with: .automatic)
+    }
+
+    func showLoadingFooter() {
+        paginationFooter.startAnimating()
+        tableView.tableFooterView = paginationFooter
+    }
+
+    func hideLoadingFooter() {
+        paginationFooter.stopAnimating()
+        tableView.tableFooterView = nil
+    }
+
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         characters.count
     }
-    
+
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell = tableView.dequeueReusableCell(withIdentifier: "ListCharactersTableViewCell", for: indexPath) as! ListCharactersTableViewCell
-        
-        let model = characters[indexPath.row]
-        cell.configure(model: model)
-        
+        cell.configure(model: characters[indexPath.row])
         return cell
     }
 }

--- a/WallaMarvel/Presentation/ListCharacter/ListCharactersPresenter.swift
+++ b/WallaMarvel/Presentation/ListCharacter/ListCharactersPresenter.swift
@@ -1,9 +1,12 @@
 import Foundation
 
+@MainActor
 protocol ListCharactersPresenterProtocol: AnyObject {
     var ui: ListCharactersUI? { get set }
     func screenTitle() -> String
     func getCharacters() async
+    func loadNextPage() async
+    func retryNextPage() async
 }
 
 @MainActor
@@ -11,32 +14,77 @@ protocol ListCharactersUI: AnyObject {
     func showLoading()
     func hideLoading()
     func update(characters: [Character])
+    func appendCharacters(_ newCharacters: [Character])
+    func showPaginationLoading()
+    func hidePaginationLoading()
     func showError(_ error: AppError)
+    func showPaginationError(_ error: AppError)
 }
 
+@MainActor
 final class ListCharactersPresenter: ListCharactersPresenterProtocol {
     var ui: ListCharactersUI?
     private let getCharactersUseCase: GetCharactersUseCaseProtocol
-    
+
+    private var currentPage = 1
+    private var hasNextPage = false
+    private var isLoadingPage = false
+    private var isPaginationBlocked = false
+
     init(getCharactersUseCase: GetCharactersUseCaseProtocol = GetCharacters()) {
         self.getCharactersUseCase = getCharactersUseCase
     }
-    
+
     func screenTitle() -> String {
         "List of Characters"
     }
-    
+
     func getCharacters() async {
-        await ui?.showLoading()
-        
+        ui?.showLoading()
+        currentPage = 1
+        hasNextPage = false
+        isLoadingPage = false
+        isPaginationBlocked = false
+
         do {
-            let characters = try await getCharactersUseCase.execute()
-            await ui?.update(characters: characters)
+            let page = try await getCharactersUseCase.execute(page: currentPage)
+            hasNextPage = page.hasNextPage
+            ui?.hideLoading()
+            ui?.update(characters: page.characters)
         } catch let error as AppError {
-            await ui?.showError(error)
+            ui?.hideLoading()
+            ui?.showError(error)
         } catch {
-            let appError = AppErrorMapper.map(error)
-            await ui?.showError(appError)
+            ui?.hideLoading()
+            ui?.showError(AppErrorMapper.map(error))
         }
+    }
+
+    func loadNextPage() async {
+        guard !isLoadingPage, hasNextPage, !isPaginationBlocked else { return }
+
+        isLoadingPage = true
+        ui?.showPaginationLoading()
+
+        do {
+            let page = try await getCharactersUseCase.execute(page: currentPage + 1)
+            currentPage += 1
+            hasNextPage = page.hasNextPage
+            ui?.appendCharacters(page.characters)
+        } catch let error as AppError {
+            isPaginationBlocked = true
+            ui?.showPaginationError(error)
+        } catch {
+            isPaginationBlocked = true
+            ui?.showPaginationError(AppErrorMapper.map(error))
+        }
+
+        ui?.hidePaginationLoading()
+        isLoadingPage = false
+    }
+
+    func retryNextPage() async {
+        isPaginationBlocked = false
+        await loadNextPage()
     }
 }

--- a/WallaMarvel/Presentation/ListCharacter/ListCharactersViewController.swift
+++ b/WallaMarvel/Presentation/ListCharacter/ListCharactersViewController.swift
@@ -1,11 +1,14 @@
 import UIKit
 
 final class ListCharactersViewController: UIViewController {
-    var mainView: ListCharactersView { return view as! ListCharactersView  }
-    
+    var mainView: ListCharactersView { return view as! ListCharactersView }
+
     var presenter: ListCharactersPresenterProtocol?
     var listCharactersProvider: ListCharactersAdapter?
-    
+
+    private let paginationThreshold = 5
+    private var isPaginatingFromScroll = false
+
     override func loadView() {
         view = ListCharactersView()
     }
@@ -17,7 +20,7 @@ final class ListCharactersViewController: UIViewController {
         Task { [weak self] in
             await self?.presenter?.getCharacters()
         }
-        
+
         title = presenter?.screenTitle()
     }
 }
@@ -26,26 +29,50 @@ extension ListCharactersViewController: ListCharactersUI {
     func showLoading() {
         mainView.showLoading()
     }
-    
+
     func hideLoading() {
         mainView.hideLoading()
     }
-    
+
     func update(characters: [Character]) {
         mainView.showCharacters()
-        listCharactersProvider?.characters = characters
+        listCharactersProvider?.setCharacters(characters)
     }
-    
+
+    func appendCharacters(_ newCharacters: [Character]) {
+        listCharactersProvider?.appendCharacters(newCharacters)
+    }
+
+    func showPaginationLoading() {
+        listCharactersProvider?.showLoadingFooter()
+    }
+
+    func hidePaginationLoading() {
+        listCharactersProvider?.hideLoadingFooter()
+    }
+
     func showError(_ error: AppError) {
         mainView.showError(message: error.userMessage)
         mainView.setRetryEnabled(true)
         mainView.setRetryTarget(self, action: #selector(handleRetryTap))
     }
-    
+
+    func showPaginationError(_ error: AppError) {
+        let alert = UIAlertController(
+            title: "Error loading more",
+            message: error.userMessage,
+            preferredStyle: .alert
+        )
+        alert.addAction(UIAlertAction(title: "Retry", style: .default) { [weak self] _ in
+            Task { [weak self] in await self?.presenter?.retryNextPage() }
+        })
+        alert.addAction(UIAlertAction(title: "Dismiss", style: .cancel))
+        present(alert, animated: true)
+    }
+
     @objc
     private func handleRetryTap() {
         mainView.setRetryEnabled(false)
-        showLoading()
         Task { [weak self] in
             await self?.presenter?.getCharacters()
         }
@@ -54,10 +81,17 @@ extension ListCharactersViewController: ListCharactersUI {
 
 extension ListCharactersViewController: UITableViewDelegate {
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        let presenter = ListCharactersPresenter()
-        let listCharactersViewController = ListCharactersViewController()
-        listCharactersViewController.presenter = presenter
-        
         // TODO: add navigation in another task
+    }
+
+    func tableView(_ tableView: UITableView, willDisplay cell: UITableViewCell, forRowAt indexPath: IndexPath) {
+        guard !isPaginatingFromScroll else { return }
+        let total = tableView.numberOfRows(inSection: 0)
+        guard total > 0, indexPath.row >= total - paginationThreshold else { return }
+        isPaginatingFromScroll = true
+        Task { @MainActor [weak self] in
+            await self?.presenter?.loadNextPage()
+            self?.isPaginatingFromScroll = false
+        }
     }
 }

--- a/WallaMarvelTests/Data/APIClientTests.swift
+++ b/WallaMarvelTests/Data/APIClientTests.swift
@@ -2,7 +2,7 @@ import XCTest
 @testable import WallaMarvel
 
 final class APIClientTests: XCTestCase {
-    private let endpoint = URL(string: "https://rickandmortyapi.com/api/character")
+    private let baseEndpoint = URL(string: "https://rickandmortyapi.com/api/character")
     private var session: URLSession!
 
     override func setUp() {
@@ -18,56 +18,123 @@ final class APIClientTests: XCTestCase {
         super.tearDown()
     }
 
-    func test_whenGetHeroes_called_shouldRequestCorrectURL() async throws {
+    func test_whenGetCharacters_called_shouldRequestCorrectBaseURL() async throws {
         var requestedURL: URL?
         let data = makeValidResponseData()
-        let response = HTTPURLResponse(url: endpoint!, statusCode: 200, httpVersion: nil, headerFields: nil)
+        let response = HTTPURLResponse(url: baseEndpoint!, statusCode: 200, httpVersion: nil, headerFields: nil)
         URLProtocolStub.startIntercepting(with: .init(data: data, response: response, error: nil, requestObserver: { request in
             requestedURL = request.url
         }))
 
         let sut = APIClient(session: session)
-        _ = try await sut.getCharacters()
+        _ = try await sut.getCharacters(page: 1)
 
-        XCTAssertEqual(requestedURL, endpoint)
+        XCTAssertEqual(requestedURL?.host, "rickandmortyapi.com")
+        XCTAssertEqual(requestedURL?.path, "/api/character")
     }
 
-    func test_whenGetHeroes_succeeds_shouldReturnDecodedModel() async throws {
+    func test_whenGetCharacters_called_shouldIncludePageQueryParameter() async throws {
+        var requestedURL: URL?
         let data = makeValidResponseData()
-        let response = HTTPURLResponse(url: endpoint!, statusCode: 200, httpVersion: nil, headerFields: nil)
+        let response = HTTPURLResponse(url: baseEndpoint!, statusCode: 200, httpVersion: nil, headerFields: nil)
+        URLProtocolStub.startIntercepting(with: .init(data: data, response: response, error: nil, requestObserver: { request in
+            requestedURL = request.url
+        }))
+
+        let sut = APIClient(session: session)
+        _ = try await sut.getCharacters(page: 3)
+
+        let components = URLComponents(url: requestedURL!, resolvingAgainstBaseURL: false)
+        let pageValue = components?.queryItems?.first(where: { $0.name == "page" })?.value
+        XCTAssertEqual(pageValue, "3")
+    }
+
+    func test_whenGetCharacters_succeeds_shouldReturnDecodedModel() async throws {
+        let data = makeValidResponseData()
+        let response = HTTPURLResponse(url: baseEndpoint!, statusCode: 200, httpVersion: nil, headerFields: nil)
         URLProtocolStub.startIntercepting(with: .init(data: data, response: response, error: nil, requestObserver: nil))
 
         let sut = APIClient(session: session)
-        let result = try await sut.getCharacters()
+        let result = try await sut.getCharacters(page: 1)
 
         XCTAssertEqual(result.results.count, 1)
     }
 
-    func test_whenGetHeroes_sessionReturnsError_shouldThrow() async {
+    func test_whenGetCharacters_sessionReturnsError_shouldThrow() async {
         URLProtocolStub.startIntercepting(with: .init(data: nil, response: nil, error: TestError.any, requestObserver: nil))
 
-        let sut = APIClient(session: session)
+        let sut = APIClient(session: session, maxRetries: 1, retryDelay: 0)
 
         do {
-            _ = try await sut.getCharacters()
+            _ = try await sut.getCharacters(page: 1)
             XCTFail("Expected error to be thrown")
         } catch {
             XCTAssertTrue(true)
         }
     }
 
-    func test_whenGetHeroes_receivesInvalidData_shouldThrow() async {
-        let response = HTTPURLResponse(url: endpoint!, statusCode: 200, httpVersion: nil, headerFields: nil)
+    func test_whenGetCharacters_receivesInvalidData_shouldThrow() async {
+        let response = HTTPURLResponse(url: baseEndpoint!, statusCode: 200, httpVersion: nil, headerFields: nil)
         URLProtocolStub.startIntercepting(with: .init(data: Data("invalid".utf8), response: response, error: nil, requestObserver: nil))
 
-        let sut = APIClient(session: session)
+        let sut = APIClient(session: session, maxRetries: 1, retryDelay: 0)
 
         do {
-            _ = try await sut.getCharacters()
+            _ = try await sut.getCharacters(page: 1)
             XCTFail("Expected error to be thrown")
         } catch {
             XCTAssertTrue(true)
         }
+    }
+
+    // MARK: - Retry
+
+    func test_whenGetCharacters_failsOnFirstAttempt_shouldRetryAndSucceed() async throws {
+        let successData = makeValidResponseData()
+        let successResponse = HTTPURLResponse(url: baseEndpoint!, statusCode: 200, httpVersion: nil, headerFields: nil)
+
+        URLProtocolStub.startIntercepting(withSequence: [
+            .init(data: nil, response: nil, error: URLError(.networkConnectionLost), requestObserver: nil),
+            .init(data: successData, response: successResponse, error: nil, requestObserver: nil)
+        ])
+
+        let sut = APIClient(session: session, maxRetries: 2, retryDelay: 0)
+        let result = try await sut.getCharacters(page: 1)
+
+        XCTAssertEqual(result.results.count, 1)
+    }
+
+    func test_whenGetCharacters_failsAllAttempts_shouldThrowLastError() async {
+        var requestCount = 0
+        URLProtocolStub.startIntercepting(withSequence: [
+            .init(data: nil, response: nil, error: URLError(.networkConnectionLost), requestObserver: { _ in requestCount += 1 }),
+            .init(data: nil, response: nil, error: URLError(.networkConnectionLost), requestObserver: { _ in requestCount += 1 }),
+            .init(data: nil, response: nil, error: URLError(.networkConnectionLost), requestObserver: { _ in requestCount += 1 })
+        ])
+
+        let sut = APIClient(session: session, maxRetries: 3, retryDelay: 0)
+
+        do {
+            _ = try await sut.getCharacters(page: 1)
+            XCTFail("Expected error to be thrown")
+        } catch {
+            XCTAssertEqual(requestCount, 3)
+        }
+    }
+
+    func test_whenGetCharacters_succeedsOnFirstAttempt_shouldNotRetry() async throws {
+        var requestCount = 0
+        let successData = makeValidResponseData()
+        let successResponse = HTTPURLResponse(url: baseEndpoint!, statusCode: 200, httpVersion: nil, headerFields: nil)
+
+        URLProtocolStub.startIntercepting(withSequence: [
+            .init(data: successData, response: successResponse, error: nil, requestObserver: { _ in requestCount += 1 })
+        ])
+
+        let sut = APIClient(session: session, maxRetries: 3, retryDelay: 0)
+        _ = try await sut.getCharacters(page: 1)
+
+        XCTAssertEqual(requestCount, 1)
     }
 
     private func makeValidResponseData() -> Data {

--- a/WallaMarvelTests/Data/CharacterDataModelMappingTests.swift
+++ b/WallaMarvelTests/Data/CharacterDataModelMappingTests.swift
@@ -10,9 +10,8 @@ final class CharacterDataModelMappingTests: XCTestCase {
             status: "Alive",
             species: "Human",
             gender: "Male",
-            image: "https://example.com/morty.png",
             origin: Origin.fixture(name: "Earth C-137"),
-            location: Location.fixture(name: "Dimension C-500"),
+            location: Location.fixture(name: "Dimension C-500"), image: "https://example.com/morty.png",
             episode: ["1", "2", "3"]
         )
         

--- a/WallaMarvelTests/Data/CharacterDataSourceTests.swift
+++ b/WallaMarvelTests/Data/CharacterDataSourceTests.swift
@@ -6,37 +6,44 @@ final class CharacterDataSourceTests: XCTestCase {
     private lazy var sut = CharacterDataSource(apiClient: apiClientSpy)
 
     func test_whenGetCharacters_called_shouldCallAPIClient() async throws {
-        _ = try await sut.getCharacters()
+        _ = try await sut.getCharacters(page: 1)
 
         XCTAssertTrue(apiClientSpy.getCharactersCalled)
     }
 
+    func test_whenGetCharacters_called_shouldPassPageToAPIClient() async throws {
+        _ = try await sut.getCharacters(page: 2)
+
+        XCTAssertEqual(apiClientSpy.lastRequestedPage, 2)
+    }
+
     func test_whenGetCharacters_succeeds_shouldReturnResultFromAPIClient() async throws {
-        let expectedContainer = CharacterDataContainer.fixture()
+        let expectedContainer = CharacterDataContainer.fixture(results: [.fixture(id: 42)])
         apiClientSpy.result = expectedContainer
 
-        let result = try await sut.getCharacters()
+        let result = try await sut.getCharacters(page: 1)
 
-        XCTAssertEqual(result, expectedContainer)
+        XCTAssertEqual(result.results.count, expectedContainer.results.count)
+        XCTAssertEqual(result.results.first?.id, expectedContainer.results.first?.id)
     }
 
     func test_whenGetCharacters_fails_shouldThrowError() async {
         apiClientSpy.error = TestError.any
 
         do {
-            _ = try await sut.getCharacters()
+            _ = try await sut.getCharacters(page: 1)
             XCTFail("Expected error to be thrown")
         } catch {
             XCTAssertTrue(apiClientSpy.getCharactersCalled)
         }
     }
-    
+
     func test_whenGetCharacters_withAPIError_shouldMapToAppError() async {
         let urlError = URLError(.notConnectedToInternet)
         apiClientSpy.error = urlError
 
         do {
-            _ = try await sut.getCharacters()
+            _ = try await sut.getCharacters(page: 1)
             XCTFail("Expected AppError to be thrown")
         } catch let error as AppError {
             if case .network = error {
@@ -47,3 +54,4 @@ final class CharacterDataSourceTests: XCTestCase {
             XCTFail("Expected AppError, got different error type")
         }
     }
+}

--- a/WallaMarvelTests/Domain/CharacterRepositoryTests.swift
+++ b/WallaMarvelTests/Domain/CharacterRepositoryTests.swift
@@ -6,38 +6,59 @@ final class CharacterRepositoryTests: XCTestCase {
     private lazy var sut = CharacterRepository(dataSource: dataSourceSpy)
 
     func test_whenGetCharacters_called_shouldCallDataSource() async throws {
-        _ = try await sut.getCharacters()
+        _ = try await sut.getCharacters(page: 1)
 
         XCTAssertTrue(dataSourceSpy.getCharactersCalled)
+    }
+
+    func test_whenGetCharacters_called_shouldPassPageToDataSource() async throws {
+        _ = try await sut.getCharacters(page: 3)
+
+        XCTAssertEqual(dataSourceSpy.lastRequestedPage, 3)
     }
 
     func test_whenGetCharacters_succeeds_shouldReturnResultFromDataSource() async throws {
         let container = CharacterDataContainer.fixture()
         dataSourceSpy.result = container
 
-        let result = try await sut.getCharacters()
+        let result = try await sut.getCharacters(page: 1)
 
-        let expectedCount = container.results.count
-        XCTAssertEqual(result.count, expectedCount)
+        XCTAssertEqual(result.characters.count, container.results.count)
+    }
+
+    func test_whenGetCharacters_withNextPage_shouldReturnHasNextPageTrue() async throws {
+        dataSourceSpy.result = .fixture(next: "https://rickandmortyapi.com/api/character?page=2")
+
+        let result = try await sut.getCharacters(page: 1)
+
+        XCTAssertTrue(result.hasNextPage)
+    }
+
+    func test_whenGetCharacters_withoutNextPage_shouldReturnHasNextPageFalse() async throws {
+        dataSourceSpy.result = .fixture(next: nil)
+
+        let result = try await sut.getCharacters(page: 42)
+
+        XCTAssertFalse(result.hasNextPage)
     }
 
     func test_whenGetCharacters_fails_shouldThrowError() async {
         dataSourceSpy.error = TestError.any
 
         do {
-            _ = try await sut.getCharacters()
+            _ = try await sut.getCharacters(page: 1)
             XCTFail("Expected error to be thrown")
         } catch {
             XCTAssertTrue(dataSourceSpy.getCharactersCalled)
         }
     }
-    
+
     func test_whenGetCharacters_withDataSourceError_shouldThrowAppError() async {
         let appError = AppError.network("Connection failed")
         dataSourceSpy.error = appError
 
         do {
-            _ = try await sut.getCharacters()
+            _ = try await sut.getCharacters(page: 1)
             XCTFail("Expected AppError to be thrown")
         } catch let error as AppError {
             XCTAssertEqual(error, appError)
@@ -45,21 +66,17 @@ final class CharacterRepositoryTests: XCTestCase {
             XCTFail("Expected AppError, got different error type")
         }
     }
-    
+
     func test_whenGetCharacters_withMappingError_shouldThrowAppError() async {
         dataSourceSpy.result = CharacterDataContainer(
-            results: [
-                CharacterDataModel.fixture(image: "")
-            ],
-            info: PageInfo.fixture()
+            info: PageInfo.fixture(), results: [.fixture(image: "")]
         )
 
         do {
-            _ = try await sut.getCharacters()
+            _ = try await sut.getCharacters(page: 1)
             XCTFail("Expected AppError to be thrown")
         } catch let error as AppError {
-            if case .invalidData = error {
-            } else {
+            if case .invalidData = error { } else {
                 XCTFail("Expected invalidData error, got \(error)")
             }
         } catch {

--- a/WallaMarvelTests/Domain/UseCases/GetCharactersTests.swift
+++ b/WallaMarvelTests/Domain/UseCases/GetCharactersTests.swift
@@ -6,25 +6,39 @@ final class GetCharactersTests: XCTestCase {
     private lazy var sut = GetCharacters(repository: repositorySpy)
 
     func test_whenExecute_called_shouldCallRepository() async throws {
-        _ = try await sut.execute()
+        _ = try await sut.execute(page: 1)
 
         XCTAssertTrue(repositorySpy.getCharactersCalled)
     }
 
+    func test_whenExecute_called_shouldPassPageToRepository() async throws {
+        _ = try await sut.execute(page: 3)
+
+        XCTAssertEqual(repositorySpy.lastRequestedPage, 3)
+    }
+
     func test_whenExecute_succeeds_shouldReturnResultFromRepository() async throws {
         let expectedCharacters = [Character.fixture()]
-        repositorySpy.result = expectedCharacters
+        repositorySpy.pageResult = CharactersPage(characters: expectedCharacters, hasNextPage: false)
 
-        let result = try await sut.execute()
+        let result = try await sut.execute(page: 1)
 
-        XCTAssertEqual(result.count, expectedCharacters.count)
+        XCTAssertEqual(result.characters.count, expectedCharacters.count)
+    }
+
+    func test_whenExecute_withNextPage_shouldReturnHasNextPageTrue() async throws {
+        repositorySpy.pageResult = CharactersPage(characters: [], hasNextPage: true)
+
+        let result = try await sut.execute(page: 1)
+
+        XCTAssertTrue(result.hasNextPage)
     }
 
     func test_whenExecute_fails_shouldThrowError() async {
         repositorySpy.error = TestError.any
 
         do {
-            _ = try await sut.execute()
+            _ = try await sut.execute(page: 1)
             XCTFail("Expected error to be thrown")
         } catch {
             XCTAssertTrue(repositorySpy.getCharactersCalled)

--- a/WallaMarvelTests/Fixtures/CharacterDataContainer+fixture.swift
+++ b/WallaMarvelTests/Fixtures/CharacterDataContainer+fixture.swift
@@ -7,4 +7,8 @@ extension CharacterDataContainer {
     ) -> Self {
         CharacterDataContainer(info: info, results: results)
     }
+
+    static func fixture(next: String?) -> Self {
+        CharacterDataContainer(info: .fixture(next: next), results: [CharacterDataModel.fixture()])
+    }
 }

--- a/WallaMarvelTests/Presentation/ListCharactersPresenterTests.swift
+++ b/WallaMarvelTests/Presentation/ListCharactersPresenterTests.swift
@@ -1,14 +1,19 @@
 import XCTest
 @testable import WallaMarvel
 
+@MainActor
 final class ListCharactersPresenterTests: XCTestCase {
     private let getCharactersUseCaseSpy = GetCharactersUseCaseSpy()
     private lazy var sut = ListCharactersPresenter(getCharactersUseCase: getCharactersUseCaseSpy)
-    
+
+    // MARK: - screenTitle
+
     func test_whenScreenTitle_called_shouldReturnCorrectTitle() {
         let result = sut.screenTitle()
         XCTAssertEqual(result, "List of Characters")
     }
+
+    // MARK: - getCharacters (initial load)
 
     func test_whenGetCharacters_called_shouldExecuteUseCase() async {
         await sut.getCharacters()
@@ -16,9 +21,15 @@ final class ListCharactersPresenterTests: XCTestCase {
         XCTAssertTrue(getCharactersUseCaseSpy.executeCalled)
     }
 
+    func test_whenGetCharacters_called_shouldRequestPageOne() async {
+        await sut.getCharacters()
+
+        XCTAssertEqual(getCharactersUseCaseSpy.lastRequestedPage, 1)
+    }
+
     func test_whenGetCharacters_succeeds_shouldUpdateUI() async {
         let expectedCharacters = [Character.fixture()]
-        getCharactersUseCaseSpy.result = expectedCharacters
+        getCharactersUseCaseSpy.pageResult = CharactersPage(characters: expectedCharacters, hasNextPage: false)
 
         let uiSpy = ListCharactersUISpy()
         sut.ui = uiSpy
@@ -39,28 +50,29 @@ final class ListCharactersPresenterTests: XCTestCase {
         XCTAssertTrue(getCharactersUseCaseSpy.executeCalled)
         XCTAssertNil(uiSpy.updatedCharactersCount)
     }
-    
+
     func test_whenGetCharacters_called_shouldShowLoading() async {
         let uiSpy = ListCharactersUISpy()
         sut.ui = uiSpy
 
         await sut.getCharacters()
 
-        XCTAssertTrue(uiSpy.isLoadingShown)
+        XCTAssertTrue(uiSpy.showLoadingWasCalled)
     }
-    
+
     func test_whenGetCharacters_succeeds_shouldHideLoading() async {
         let expectedCharacters = [Character.fixture()]
-        getCharactersUseCaseSpy.result = expectedCharacters
-        
+        getCharactersUseCaseSpy.pageResult = CharactersPage(characters: expectedCharacters, hasNextPage: false)
+
         let uiSpy = ListCharactersUISpy()
         sut.ui = uiSpy
 
         await sut.getCharacters()
 
+        XCTAssertTrue(uiSpy.hideLoadingWasCalled)
         XCTAssertFalse(uiSpy.isLoadingShown)
     }
-    
+
     func test_whenGetCharacters_withAppError_shouldShowErrorWithUserFriendlyMessage() async {
         let appError = AppError.network("Connection failed")
         getCharactersUseCaseSpy.error = appError
@@ -70,9 +82,10 @@ final class ListCharactersPresenterTests: XCTestCase {
 
         await sut.getCharacters()
 
+        XCTAssertTrue(uiSpy.hideLoadingWasCalled)
         XCTAssertEqual(uiSpy.lastShownError, appError)
     }
-    
+
     func test_whenGetCharacters_withGenericError_shouldMapToAppError() async {
         getCharactersUseCaseSpy.error = TestError.any
 
@@ -83,3 +96,144 @@ final class ListCharactersPresenterTests: XCTestCase {
 
         XCTAssertNotNil(uiSpy.lastShownError)
     }
+
+    // MARK: - loadNextPage
+
+    func test_whenLoadNextPage_withoutHasNextPage_shouldNotCallUseCase() async {
+        getCharactersUseCaseSpy.pageResult = CharactersPage(characters: [.fixture()], hasNextPage: false)
+        let uiSpy = ListCharactersUISpy()
+        sut.ui = uiSpy
+
+        await sut.getCharacters()
+        getCharactersUseCaseSpy.resetCallTracking()
+
+        await sut.loadNextPage()
+
+        XCTAssertFalse(getCharactersUseCaseSpy.executeCalled)
+    }
+
+    func test_whenLoadNextPage_withHasNextPage_shouldRequestNextPage() async {
+        getCharactersUseCaseSpy.pageResult = CharactersPage(characters: [.fixture()], hasNextPage: true)
+        let uiSpy = ListCharactersUISpy()
+        sut.ui = uiSpy
+
+        await sut.getCharacters()
+        getCharactersUseCaseSpy.pageResult = CharactersPage(characters: [.fixture(id: 2)], hasNextPage: false)
+
+        await sut.loadNextPage()
+
+        XCTAssertEqual(getCharactersUseCaseSpy.lastRequestedPage, 2)
+    }
+
+    func test_whenLoadNextPage_succeeds_shouldAppendCharactersToUI() async {
+        getCharactersUseCaseSpy.pageResult = CharactersPage(characters: [.fixture()], hasNextPage: true)
+        let uiSpy = ListCharactersUISpy()
+        sut.ui = uiSpy
+
+        await sut.getCharacters()
+
+        let nextPageCharacters = [Character.fixture(id: 2), Character.fixture(id: 3)]
+        getCharactersUseCaseSpy.pageResult = CharactersPage(characters: nextPageCharacters, hasNextPage: false)
+
+        await sut.loadNextPage()
+
+        XCTAssertEqual(uiSpy.appendedCharacters.count, nextPageCharacters.count)
+    }
+
+    func test_whenLoadNextPage_succeeds_shouldShowAndHidePaginationLoading() async {
+        getCharactersUseCaseSpy.pageResult = CharactersPage(characters: [.fixture()], hasNextPage: true)
+        let uiSpy = ListCharactersUISpy()
+        sut.ui = uiSpy
+
+        await sut.getCharacters()
+        getCharactersUseCaseSpy.pageResult = CharactersPage(characters: [.fixture(id: 2)], hasNextPage: false)
+
+        await sut.loadNextPage()
+
+        XCTAssertTrue(uiSpy.showPaginationLoadingWasCalled)
+        XCTAssertFalse(uiSpy.isPaginationLoadingShown)
+    }
+
+    func test_whenLoadNextPage_fails_shouldShowPaginationError() async {
+        getCharactersUseCaseSpy.pageResult = CharactersPage(characters: [.fixture()], hasNextPage: true)
+        let uiSpy = ListCharactersUISpy()
+        sut.ui = uiSpy
+
+        await sut.getCharacters()
+
+        getCharactersUseCaseSpy.error = AppError.network("Page load failed")
+        await sut.loadNextPage()
+
+        XCTAssertNotNil(uiSpy.lastPaginationError)
+    }
+
+    func test_whenLoadNextPage_fails_shouldNotUpdateExistingCharacters() async {
+        let initialCharacters = [Character.fixture()]
+        getCharactersUseCaseSpy.pageResult = CharactersPage(characters: initialCharacters, hasNextPage: true)
+        let uiSpy = ListCharactersUISpy()
+        sut.ui = uiSpy
+
+        await sut.getCharacters()
+
+        getCharactersUseCaseSpy.error = AppError.network("Page load failed")
+        await sut.loadNextPage()
+
+        XCTAssertEqual(uiSpy.updatedCharactersCount, initialCharacters.count)
+        XCTAssertTrue(uiSpy.appendedCharacters.isEmpty)
+    }
+
+    func test_whenLoadNextPage_fails_shouldAllowRetryViaRetryNextPage() async {
+        getCharactersUseCaseSpy.pageResult = CharactersPage(characters: [.fixture()], hasNextPage: true)
+        let uiSpy = ListCharactersUISpy()
+        sut.ui = uiSpy
+
+        await sut.getCharacters()
+
+        getCharactersUseCaseSpy.error = AppError.network("Page load failed")
+        await sut.loadNextPage()
+
+        getCharactersUseCaseSpy.error = nil
+        getCharactersUseCaseSpy.pageResult = CharactersPage(characters: [.fixture(id: 2)], hasNextPage: false)
+        await sut.retryNextPage()
+
+        XCTAssertEqual(uiSpy.appendedCharacters.count, 1)
+    }
+
+    func test_whenLoadNextPage_fails_shouldBlockSubsequentAutoLoads() async {
+        getCharactersUseCaseSpy.pageResult = CharactersPage(characters: [.fixture()], hasNextPage: true)
+        let uiSpy = ListCharactersUISpy()
+        sut.ui = uiSpy
+
+        await sut.getCharacters()
+
+        getCharactersUseCaseSpy.error = AppError.network("failed")
+        await sut.loadNextPage()
+        getCharactersUseCaseSpy.error = nil
+        getCharactersUseCaseSpy.resetCallTracking()
+
+        // Simulating willDisplay triggering again after error — should be blocked
+        await sut.loadNextPage()
+
+        XCTAssertFalse(getCharactersUseCaseSpy.executeCalled)
+    }
+
+    func test_whenRetryNextPage_afterError_shouldCallUseCaseAgain() async {
+        getCharactersUseCaseSpy.pageResult = CharactersPage(characters: [.fixture()], hasNextPage: true)
+        let uiSpy = ListCharactersUISpy()
+        sut.ui = uiSpy
+
+        await sut.getCharacters()
+
+        getCharactersUseCaseSpy.error = AppError.network("failed")
+        await sut.loadNextPage()
+
+        getCharactersUseCaseSpy.error = nil
+        getCharactersUseCaseSpy.pageResult = CharactersPage(characters: [.fixture(id: 2)], hasNextPage: false)
+        getCharactersUseCaseSpy.resetCallTracking()
+
+        await sut.retryNextPage()
+
+        XCTAssertTrue(getCharactersUseCaseSpy.executeCalled)
+        XCTAssertEqual(uiSpy.appendedCharacters.count, 1)
+    }
+}

--- a/WallaMarvelTests/Spies/APIClientSpy.swift
+++ b/WallaMarvelTests/Spies/APIClientSpy.swift
@@ -2,11 +2,13 @@
 
 final class APIClientSpy: APIClientProtocol {
     private(set) var getCharactersCalled: Bool = false
+    private(set) var lastRequestedPage: Int = 0
     var result: CharacterDataContainer = .fixture()
     var error: Error?
 
-    func getCharacters() async throws -> CharacterDataContainer {
+    func getCharacters(page: Int) async throws -> CharacterDataContainer {
         getCharactersCalled = true
+        lastRequestedPage = page
         if let error {
             throw error
         }

--- a/WallaMarvelTests/Spies/CharacterDataSourceSpy.swift
+++ b/WallaMarvelTests/Spies/CharacterDataSourceSpy.swift
@@ -2,11 +2,13 @@
 
 final class CharacterDataSourceSpy: CharacterDataSourceProtocol {
     private(set) var getCharactersCalled: Bool = false
+    private(set) var lastRequestedPage: Int = 0
     var result: CharacterDataContainer = .fixture()
     var error: Error?
 
-    func getCharacters() async throws -> CharacterDataContainer {
+    func getCharacters(page: Int) async throws -> CharacterDataContainer {
         getCharactersCalled = true
+        lastRequestedPage = page
         if let error {
             throw error
         }

--- a/WallaMarvelTests/Spies/CharacterRepositorySpy.swift
+++ b/WallaMarvelTests/Spies/CharacterRepositorySpy.swift
@@ -2,14 +2,16 @@
 
 final class CharacterRepositorySpy: CharacterRepositoryProtocol {
     private(set) var getCharactersCalled: Bool = false
-    var result: [Character] = []
+    private(set) var lastRequestedPage: Int = 0
+    var pageResult: CharactersPage = CharactersPage(characters: [], hasNextPage: false)
     var error: Error?
 
-    func getCharacters() async throws -> [Character] {
+    func getCharacters(page: Int) async throws -> CharactersPage {
         getCharactersCalled = true
+        lastRequestedPage = page
         if let error {
             throw error
         }
-        return result
+        return pageResult
     }
 }

--- a/WallaMarvelTests/Spies/GetCharactersUseCaseSpy.swift
+++ b/WallaMarvelTests/Spies/GetCharactersUseCaseSpy.swift
@@ -2,14 +2,21 @@
 
 final class GetCharactersUseCaseSpy: GetCharactersUseCaseProtocol {
     private(set) var executeCalled: Bool = false
-    var result: [Character] = []
+    private(set) var lastRequestedPage: Int = 0
+    var pageResult: CharactersPage = CharactersPage(characters: [], hasNextPage: false)
     var error: Error?
 
-    func execute() async throws -> [Character] {
+    func execute(page: Int) async throws -> CharactersPage {
         executeCalled = true
+        lastRequestedPage = page
         if let error {
             throw error
         }
-        return result
+        return pageResult
+    }
+
+    func resetCallTracking() {
+        executeCalled = false
+        lastRequestedPage = 0
     }
 }

--- a/WallaMarvelTests/Spies/ListCharactersUISpy.swift
+++ b/WallaMarvelTests/Spies/ListCharactersUISpy.swift
@@ -3,8 +3,14 @@ import XCTest
 
 final class ListCharactersUISpy: ListCharactersUI {
     private(set) var updatedCharactersCount: Int?
+    private(set) var appendedCharacters: [Character] = []
     private(set) var lastShownError: AppError?
+    private(set) var lastPaginationError: AppError?
     private(set) var isLoadingShown: Bool = false
+    private(set) var showLoadingWasCalled: Bool = false
+    private(set) var hideLoadingWasCalled: Bool = false
+    private(set) var isPaginationLoadingShown: Bool = false
+    private(set) var showPaginationLoadingWasCalled: Bool = false
     private let updateExpectation: XCTestExpectation?
 
     init(updateExpectation: XCTestExpectation? = nil) {
@@ -13,19 +19,37 @@ final class ListCharactersUISpy: ListCharactersUI {
 
     func showLoading() {
         isLoadingShown = true
+        showLoadingWasCalled = true
     }
-    
+
     func hideLoading() {
         isLoadingShown = false
+        hideLoadingWasCalled = true
     }
 
     func update(characters: [Character]) {
         updatedCharactersCount = characters.count
         updateExpectation?.fulfill()
     }
-    
+
+    func appendCharacters(_ newCharacters: [Character]) {
+        appendedCharacters.append(contentsOf: newCharacters)
+    }
+
+    func showPaginationLoading() {
+        isPaginationLoadingShown = true
+        showPaginationLoadingWasCalled = true
+    }
+
+    func hidePaginationLoading() {
+        isPaginationLoadingShown = false
+    }
+
     func showError(_ error: AppError) {
         lastShownError = error
     }
-}
+
+    func showPaginationError(_ error: AppError) {
+        lastPaginationError = error
+    }
 }

--- a/WallaMarvelTests/Utils/URLProtocolStub.swift
+++ b/WallaMarvelTests/Utils/URLProtocolStub.swift
@@ -9,13 +9,30 @@ final class URLProtocolStub: URLProtocol {
     }
 
     static var stub: Stub?
+    private static var stubSequence: [Stub] = []
+    private static var sequenceIndex = 0
+    private static let lock = NSLock()
 
     static func startIntercepting(with stub: Stub) {
         self.stub = stub
+        stubSequence = []
+        sequenceIndex = 0
+    }
+
+    static func startIntercepting(withSequence stubs: [Stub]) {
+        stub = nil
+        lock.lock()
+        stubSequence = stubs
+        sequenceIndex = 0
+        lock.unlock()
     }
 
     static func stopIntercepting() {
         stub = nil
+        lock.lock()
+        stubSequence = []
+        sequenceIndex = 0
+        lock.unlock()
     }
 
     override class func canInit(with request: URLRequest) -> Bool {
@@ -27,22 +44,24 @@ final class URLProtocolStub: URLProtocol {
     }
 
     override func startLoading() {
-        guard let stub = URLProtocolStub.stub else {
+        let currentStub = resolveStub()
+
+        guard let currentStub else {
             client?.urlProtocol(self, didFailWithError: URLError(.unknown))
             return
         }
 
-        stub.requestObserver?(request)
+        currentStub.requestObserver?(request)
 
-        if let response = stub.response {
+        if let response = currentStub.response {
             client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
         }
 
-        if let data = stub.data {
+        if let data = currentStub.data {
             client?.urlProtocol(self, didLoad: data)
         }
 
-        if let error = stub.error {
+        if let error = currentStub.error {
             client?.urlProtocol(self, didFailWithError: error)
             return
         }
@@ -51,4 +70,16 @@ final class URLProtocolStub: URLProtocol {
     }
 
     override func stopLoading() { }
+
+    private func resolveStub() -> Stub? {
+        if let stub = URLProtocolStub.stub {
+            return stub
+        }
+        URLProtocolStub.lock.lock()
+        defer { URLProtocolStub.lock.unlock() }
+        guard URLProtocolStub.sequenceIndex < URLProtocolStub.stubSequence.count else { return nil }
+        let stub = URLProtocolStub.stubSequence[URLProtocolStub.sequenceIndex]
+        URLProtocolStub.sequenceIndex += 1
+        return stub
+    }
 }


### PR DESCRIPTION
## Summary
- Implemented incremental pagination across all layers (APIClient → Presenter → ViewController)
- Added `CharactersPage` domain entity with `characters` and `hasNextPage`
- Added scroll-triggered pagination via `willDisplay` with race condition protection
- Added retry with exponential backoff in `APIClient` — up to 3 attempts, delay grows as `attempt × retryDelay` nanoseconds (injectable for testability)
- Fixed `hideLoading()` not being called explicitly after load/error
- Fixed `Character` URL validation to require http/https scheme
- Extended `URLProtocolStub` with sequence support for retry testing
- Added/updated unit tests across all layers

## Context
- The list had no pagination — all characters loaded at once
- Rick & Morty API applies rate limiting, causing intermittent failures on scroll
- Multiple concurrent `Task {}` in `willDisplay` created race conditions on the loading flag
- Retry lives exclusively in `APIClient` to respect SRP — upper layers are unaware of it

## Evidences
| Loading error | Infinity scroll | 
|--------|--------|
| <img width="290"  alt="Simulator Screenshot - iPhone 17 Pro - 2026-04-03 at 00 54 10" src="https://github.com/user-attachments/assets/ceddb2b6-2a7d-445d-9317-07817a825ba7" /> | ![Simulator Screen Recording - iPhone 17 Pro - 2026-04-03 at 01 27 45](https://github.com/user-attachments/assets/55538027-81af-4822-acb1-df870f4b2cd1) | 

## Changes
- `Character.swift` — added `CharactersPage`; tightened URL validation (http/https scheme required)
- `APIClient` — `getCharacters(page:)` + retry loop (`maxRetries`, `retryDelay` injectable via `init`)
- `CharacterDataSource`, `CharacterRepository`, `GetCharacters` — propagated `page:` parameter
- `ListCharactersPresenter` — pagination state (`currentPage`, `hasNextPage`, `isPaginationBlocked`), `loadNextPage()`, `retryNextPage()`; explicit `hideLoading()` on all paths
- `ListCharactersViewController` — `isPaginatingFromScroll` flag; `Task { @MainActor }` in `willDisplay`
- `ListCharactersAdapter` — `appendCharacters()`, footer spinner
- All spies updated for new signatures
- `URLProtocolStub` — `startIntercepting(withSequence:)` for multi-response test scenarios

## Tests
**What was tested:**
- `APIClient`: page query param, retry-and-succeed, exhaust all attempts, no retry on success
- `CharacterDataSource`: page forwarding, error mapping
- `CharacterRepository`: `hasNextPage` true/false, mapping error propagation
- `GetCharacters`: page forwarding, `CharactersPage` return
- `ListCharactersPresenter`: initial load, pagination, error blocking, retry, loading lifecycle
- `CharacterDataModelMapping`: invalid URL scheme now correctly throws

**How it was validated:**
- Spy pattern across all layers + `URLProtocolStub` sequence stubs for integration-style retry coverage