### PR TITLE
[WP-04] Introduce Coordinator pattern to manage navigation flow

### DIFF
--- a/WallaMarvel.xcodeproj/project.pbxproj
+++ b/WallaMarvel.xcodeproj/project.pbxproj
@@ -57,6 +57,19 @@
 		C0E34B0FEA5F574586DAEE37 /* AppErrorMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 098896F8E8ADBCEA320C7B48 /* AppErrorMapper.swift */; };
 		F585F2C321223DDD15051939 /* AppError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DCD5856E0C7CEDDA14C48D5 /* AppError.swift */; };
 		F8958390974A92B22B51A0CE /* AppErrorMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7331CFD7344EAA013BAF60E8 /* AppErrorMapperTests.swift */; };
+		ECEE354E22C34945A90688BC /* Coordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFDCAA3E5318472B9C43F70A /* Coordinator.swift */; };
+		70FE356A1D2E46CF8F23A409 /* AppCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34806026B7C74446890FEAAA /* AppCoordinator.swift */; };
+		C1E036C813C242EE8DC3E642 /* ListCharactersCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B8FD56AF9DD44179F23488E /* ListCharactersCoordinator.swift */; };
+		4FDB7E18878F4109925B5550 /* DetailCharacterCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E58D2A6FF494563B81B0AB6 /* DetailCharacterCoordinator.swift */; };
+		32E1A29D39CE4052BCCBD93D /* DetailCharacterViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DF9F54FF44D48C59E7A512B /* DetailCharacterViewController.swift */; };
+		BBB2C3D4E5F6789012345678 /* NavigationCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAB1C2D3E4F567890A1B2C3D /* NavigationCoordinator.swift */; };
+		9941029E5E8B4E1C841B9595 /* CoordinatorSpy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 361D2986EC92485BBE27626D /* CoordinatorSpy.swift */; };
+		AAA33E7B86424403B41EE494 /* NavigationControllerSpy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62812BA212B04EA0A3332DAF /* NavigationControllerSpy.swift */; };
+		62A64D24FBF148FC9C96B7B6 /* ListCharactersPresenterSpy.swift in Sources */ = {isa = PBXBuildFile; fileRef = F999718C32A14F03B57291BA /* ListCharactersPresenterSpy.swift */; };
+		11C665E1A0434754BC325478 /* NavigationCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F50F999FDC134F2FBC1AE674 /* NavigationCoordinatorTests.swift */; };
+		0D6A93A4DA0047F880E557F5 /* AppCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81E290EAA75A481AABB9C916 /* AppCoordinatorTests.swift */; };
+		84B2CDB4B18C4BCFB1E2DF7C /* ListCharactersCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 394E89142B384D20ABA450E9 /* ListCharactersCoordinatorTests.swift */; };
+		BCF398D17CBB47258DAB5072 /* DetailCharacterCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DD07A1D63744C428AD00498 /* DetailCharacterCoordinatorTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -130,6 +143,19 @@
 		1DCD5856E0C7CEDDA14C48D5 /* AppError.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AppError.swift; path = WallaMarvel/Domain/Errors/AppError.swift; sourceTree = "<group>"; };
 		7331CFD7344EAA013BAF60E8 /* AppErrorMapperTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AppErrorMapperTests.swift; sourceTree = "<group>"; };
 		9D28C8FF45D193ADF868F043 /* AppErrorTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AppErrorTests.swift; sourceTree = "<group>"; };
+		CFDCAA3E5318472B9C43F70A /* Coordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Coordinator.swift; sourceTree = "<group>"; };
+		34806026B7C74446890FEAAA /* AppCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppCoordinator.swift; sourceTree = "<group>"; };
+		9B8FD56AF9DD44179F23488E /* ListCharactersCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListCharactersCoordinator.swift; sourceTree = "<group>"; };
+		5E58D2A6FF494563B81B0AB6 /* DetailCharacterCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailCharacterCoordinator.swift; sourceTree = "<group>"; };
+		3DF9F54FF44D48C59E7A512B /* DetailCharacterViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailCharacterViewController.swift; sourceTree = "<group>"; };
+		AAB1C2D3E4F567890A1B2C3D /* NavigationCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationCoordinator.swift; sourceTree = "<group>"; };
+		361D2986EC92485BBE27626D /* CoordinatorSpy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoordinatorSpy.swift; sourceTree = "<group>"; };
+		62812BA212B04EA0A3332DAF /* NavigationControllerSpy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationControllerSpy.swift; sourceTree = "<group>"; };
+		F999718C32A14F03B57291BA /* ListCharactersPresenterSpy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListCharactersPresenterSpy.swift; sourceTree = "<group>"; };
+		F50F999FDC134F2FBC1AE674 /* NavigationCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationCoordinatorTests.swift; sourceTree = "<group>"; };
+		81E290EAA75A481AABB9C916 /* AppCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppCoordinatorTests.swift; sourceTree = "<group>"; };
+		394E89142B384D20ABA450E9 /* ListCharactersCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListCharactersCoordinatorTests.swift; sourceTree = "<group>"; };
+		1DD07A1D63744C428AD00498 /* DetailCharacterCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailCharacterCoordinatorTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -234,6 +260,7 @@
 		1A821EC52862FD500024D397 /* DetailCharacter */ = {
 			isa = PBXGroup;
 			children = (
+				3DF9F54FF44D48C59E7A512B /* DetailCharacterViewController.swift */,
 			);
 			path = DetailCharacter;
 			sourceTree = "<group>";
@@ -284,9 +311,22 @@
 		1A8F39CD2F7DF583005F4921 /* Presentation */ = {
 			isa = PBXGroup;
 			children = (
+				9F11DE6BE37B4086AF398B8F /* Coordinators */,
 				1A821EC42862FD470024D397 /* ListCharacter */,
 			);
 			path = Presentation;
+			sourceTree = "<group>";
+		};
+		9F11DE6BE37B4086AF398B8F /* Coordinators */ = {
+			isa = PBXGroup;
+			children = (
+				CFDCAA3E5318472B9C43F70A /* Coordinator.swift */,
+				AAB1C2D3E4F567890A1B2C3D /* NavigationCoordinator.swift */,
+				34806026B7C74446890FEAAA /* AppCoordinator.swift */,
+				9B8FD56AF9DD44179F23488E /* ListCharactersCoordinator.swift */,
+				5E58D2A6FF494563B81B0AB6 /* DetailCharacterCoordinator.swift */,
+			);
+			path = Coordinators;
 			sourceTree = "<group>";
 		};
 		1AA67B832F7E13FE002C7F2E /* Domain */ = {
@@ -355,6 +395,10 @@
 			isa = PBXGroup;
 			children = (
 				1AE537C62F7E08E0008BABB4 /* ListCharactersPresenterTests.swift */,
+				F50F999FDC134F2FBC1AE674 /* NavigationCoordinatorTests.swift */,
+				81E290EAA75A481AABB9C916 /* AppCoordinatorTests.swift */,
+				394E89142B384D20ABA450E9 /* ListCharactersCoordinatorTests.swift */,
+				1DD07A1D63744C428AD00498 /* DetailCharacterCoordinatorTests.swift */,
 			);
 			path = Presentation;
 			sourceTree = "<group>";
@@ -367,6 +411,9 @@
 				1AA67B812F7E13EF002C7F2E /* CharacterRepositorySpy.swift */,
 				1AA67B8D2F7E1504002C7F2E /* APIClientSpy.swift */,
 				1AA67B8F2F7E1508002C7F2E /* CharacterDataSourceSpy.swift */,
+				361D2986EC92485BBE27626D /* CoordinatorSpy.swift */,
+				62812BA212B04EA0A3332DAF /* NavigationControllerSpy.swift */,
+				F999718C32A14F03B57291BA /* ListCharactersPresenterSpy.swift */,
 			);
 			path = Spies;
 			sourceTree = "<group>";
@@ -572,6 +619,12 @@
 				1AA67B992F7E1EA6002C7F2E /* Character.swift in Sources */,
 				F585F2C321223DDD15051939 /* AppError.swift in Sources */,
 				C0E34B0FEA5F574586DAEE37 /* AppErrorMapper.swift in Sources */,
+				ECEE354E22C34945A90688BC /* Coordinator.swift in Sources */,
+				70FE356A1D2E46CF8F23A409 /* AppCoordinator.swift in Sources */,
+				C1E036C813C242EE8DC3E642 /* ListCharactersCoordinator.swift in Sources */,
+				4FDB7E18878F4109925B5550 /* DetailCharacterCoordinator.swift in Sources */,
+				32E1A29D39CE4052BCCBD93D /* DetailCharacterViewController.swift in Sources */,
+				BBB2C3D4E5F6789012345678 /* NavigationCoordinator.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -602,6 +655,13 @@
 				1AE537D32F7E0BE8008BABB4 /* Location+fixture.swift in Sources */,
 				F8958390974A92B22B51A0CE /* AppErrorMapperTests.swift in Sources */,
 				6FF50D79AFADE4D4FA3E6F4A /* AppErrorTests.swift in Sources */,
+				9941029E5E8B4E1C841B9595 /* CoordinatorSpy.swift in Sources */,
+				AAA33E7B86424403B41EE494 /* NavigationControllerSpy.swift in Sources */,
+				62A64D24FBF148FC9C96B7B6 /* ListCharactersPresenterSpy.swift in Sources */,
+				11C665E1A0434754BC325478 /* NavigationCoordinatorTests.swift in Sources */,
+				0D6A93A4DA0047F880E557F5 /* AppCoordinatorTests.swift in Sources */,
+				84B2CDB4B18C4BCFB1E2DF7C /* ListCharactersCoordinatorTests.swift in Sources */,
+				BCF398D17CBB47258DAB5072 /* DetailCharacterCoordinatorTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/WallaMarvel/Presentation/Coordinators/AppCoordinator.swift
+++ b/WallaMarvel/Presentation/Coordinators/AppCoordinator.swift
@@ -1,0 +1,21 @@
+import UIKit
+
+final class AppCoordinator: NavigationCoordinator {
+    private let window: UIWindow
+    private let rootCoordinator: Coordinator
+
+    override var rootViewController: UIViewController { navigationController }
+
+    init(window: UIWindow, navigationController: UINavigationController, rootCoordinator: Coordinator) {
+        self.window = window
+        self.rootCoordinator = rootCoordinator
+        super.init(navigationController: navigationController)
+    }
+
+    @MainActor
+    override func start() {
+        window.rootViewController = navigationController
+        window.makeKeyAndVisible()
+        addChild(rootCoordinator)
+    }
+}

--- a/WallaMarvel/Presentation/Coordinators/Coordinator.swift
+++ b/WallaMarvel/Presentation/Coordinators/Coordinator.swift
@@ -1,0 +1,7 @@
+import UIKit
+
+protocol Coordinator: AnyObject {
+    var navigationController: UINavigationController { get }
+    var rootViewController: UIViewController { get }
+    @MainActor func start()
+}

--- a/WallaMarvel/Presentation/Coordinators/DetailCharacterCoordinator.swift
+++ b/WallaMarvel/Presentation/Coordinators/DetailCharacterCoordinator.swift
@@ -1,0 +1,17 @@
+import UIKit
+
+final class DetailCharacterCoordinator: NavigationCoordinator {
+    private let viewController: DetailCharacterViewController
+
+    override var rootViewController: UIViewController { viewController }
+
+    init(navigationController: UINavigationController, viewController: DetailCharacterViewController) {
+        self.viewController = viewController
+        super.init(navigationController: navigationController)
+    }
+
+    @MainActor
+    override func start() {
+        navigationController.pushViewController(viewController, animated: true)
+    }
+}

--- a/WallaMarvel/Presentation/Coordinators/ListCharactersCoordinator.swift
+++ b/WallaMarvel/Presentation/Coordinators/ListCharactersCoordinator.swift
@@ -1,0 +1,42 @@
+import UIKit
+
+protocol ListCharactersCoordinatorProtocol: AnyObject {
+    @MainActor func showDetail(for character: Character)
+}
+
+final class ListCharactersCoordinator: NavigationCoordinator {
+    private let viewController: ListCharactersViewController
+    private let presenter: ListCharactersPresenterProtocol
+
+    override var rootViewController: UIViewController { viewController }
+
+    init(
+        navigationController: UINavigationController,
+        viewController: ListCharactersViewController,
+        presenter: ListCharactersPresenterProtocol
+    ) {
+        self.viewController = viewController
+        self.presenter = presenter
+        super.init(navigationController: navigationController)
+    }
+
+    @MainActor
+    override func start() {
+        viewController.presenter = presenter
+        viewController.coordinator = self
+        navigationController.delegate = self
+        navigationController.pushViewController(viewController, animated: false)
+    }
+}
+
+extension ListCharactersCoordinator: ListCharactersCoordinatorProtocol {
+    @MainActor
+    func showDetail(for character: Character) {
+        let detailViewController = DetailCharacterViewController(character: character)
+        let coordinator = DetailCharacterCoordinator(
+            navigationController: navigationController,
+            viewController: detailViewController
+        )
+        addChild(coordinator)
+    }
+}

--- a/WallaMarvel/Presentation/Coordinators/NavigationCoordinator.swift
+++ b/WallaMarvel/Presentation/Coordinators/NavigationCoordinator.swift
@@ -1,0 +1,43 @@
+import UIKit
+
+class NavigationCoordinator: NSObject, Coordinator {
+    let navigationController: UINavigationController
+    var rootViewController: UIViewController {
+        fatalError("Subclasses of NavigationCoordinator must override rootViewController")
+    }
+    private(set) var childCoordinators: [Coordinator] = []
+
+    init(navigationController: UINavigationController) {
+        self.navigationController = navigationController
+    }
+
+    @MainActor
+    func start() {}
+
+    @MainActor
+    func addChild(_ coordinator: Coordinator) {
+        childCoordinators.append(coordinator)
+        coordinator.start()
+    }
+
+    @MainActor
+    func removeChild(_ coordinator: Coordinator) {
+        childCoordinators.removeAll { $0 === coordinator }
+    }
+}
+
+extension NavigationCoordinator: UINavigationControllerDelegate {
+    @MainActor
+    func navigationController(
+        _ navigationController: UINavigationController,
+        didShow viewController: UIViewController,
+        animated: Bool
+    ) {
+        guard
+            let fromViewController = navigationController.transitionCoordinator?.viewController(forKey: .from),
+            !navigationController.viewControllers.contains(fromViewController)
+        else { return }
+
+        childCoordinators.removeAll { $0.rootViewController === fromViewController }
+    }
+}

--- a/WallaMarvel/Presentation/ListCharacter/DetailCharacter/DetailCharacterViewController.swift
+++ b/WallaMarvel/Presentation/ListCharacter/DetailCharacter/DetailCharacterViewController.swift
@@ -1,0 +1,20 @@
+import UIKit
+
+final class DetailCharacterViewController: UIViewController {
+    private let character: Character
+
+    init(character: Character) {
+        self.character = character
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view.backgroundColor = .systemBackground
+        title = character.name
+    }
+}

--- a/WallaMarvel/Presentation/ListCharacter/ListCharactersViewController.swift
+++ b/WallaMarvel/Presentation/ListCharacter/ListCharactersViewController.swift
@@ -5,6 +5,7 @@ final class ListCharactersViewController: UIViewController {
 
     var presenter: ListCharactersPresenterProtocol?
     var listCharactersProvider: ListCharactersAdapter?
+    weak var coordinator: ListCharactersCoordinatorProtocol?
 
     private let paginationThreshold = 5
     private var isPaginatingFromScroll = false
@@ -81,7 +82,8 @@ extension ListCharactersViewController: ListCharactersUI {
 
 extension ListCharactersViewController: UITableViewDelegate {
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        // TODO: add navigation in another task
+        guard let character = listCharactersProvider?.characters[indexPath.row] else { return }
+        coordinator?.showDetail(for: character)
     }
 
     func tableView(_ tableView: UITableView, willDisplay cell: UITableViewCell, forRowAt indexPath: IndexPath) {

--- a/WallaMarvel/SceneDelegate.swift
+++ b/WallaMarvel/SceneDelegate.swift
@@ -3,20 +3,30 @@ import UIKit
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
     var window: UIWindow?
-    
+    private var appCoordinator: AppCoordinator?
+
+    @MainActor
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
         guard let windowScene = (scene as? UIWindowScene) else { return }
-        
+
         let window = UIWindow(windowScene: windowScene)
-        
-        let presenter = ListCharactersPresenter()
-        let listCharactersViewController = ListCharactersViewController()
-        listCharactersViewController.presenter = presenter
-        
-        let navigationController = UINavigationController(rootViewController: listCharactersViewController)
-        window.rootViewController = navigationController
         self.window = window
-        self.window?.makeKeyAndVisible()
+
+        let navigationController = UINavigationController()
+        let presenter = ListCharactersPresenter()
+        let listViewController = ListCharactersViewController()
+        let listCoordinator = ListCharactersCoordinator(
+            navigationController: navigationController,
+            viewController: listViewController,
+            presenter: presenter
+        )
+        let coordinator = AppCoordinator(
+            window: window,
+            navigationController: navigationController,
+            rootCoordinator: listCoordinator
+        )
+        appCoordinator = coordinator
+        coordinator.start()
     }
 }
 

--- a/WallaMarvelTests/Presentation/AppCoordinatorTests.swift
+++ b/WallaMarvelTests/Presentation/AppCoordinatorTests.swift
@@ -1,0 +1,28 @@
+import XCTest
+@testable import WallaMarvel
+
+@MainActor
+final class AppCoordinatorTests: XCTestCase {
+    private let navigationController = NavigationControllerSpy()
+    private let rootCoordinatorSpy = CoordinatorSpy()
+    private lazy var window: UIWindow = UIWindow()
+    private lazy var sut = AppCoordinator(
+        window: window,
+        navigationController: navigationController,
+        rootCoordinator: rootCoordinatorSpy
+    )
+
+    // MARK: - start
+
+    func test_whenStart_called_shouldSetWindowRootViewController() {
+        sut.start()
+
+        XCTAssertTrue(window.rootViewController === navigationController)
+    }
+
+    func test_whenStart_called_shouldCallStartOnRootCoordinator() {
+        sut.start()
+
+        XCTAssertTrue(rootCoordinatorSpy.startCalled)
+    }
+}

--- a/WallaMarvelTests/Presentation/DetailCharacterCoordinatorTests.swift
+++ b/WallaMarvelTests/Presentation/DetailCharacterCoordinatorTests.swift
@@ -1,0 +1,32 @@
+import XCTest
+@testable import WallaMarvel
+
+@MainActor
+final class DetailCharacterCoordinatorTests: XCTestCase {
+    private let navigationController = NavigationControllerSpy()
+    private let detailViewController = DetailCharacterViewController(character: .fixture())
+    private lazy var sut = DetailCharacterCoordinator(
+        navigationController: navigationController,
+        viewController: detailViewController
+    )
+
+    // MARK: - rootViewController
+
+    func test_rootViewController_shouldBeDetailCharacterViewController() {
+        XCTAssertTrue(sut.rootViewController === detailViewController)
+    }
+
+    // MARK: - start
+
+    func test_whenStart_called_shouldPushDetailViewControllerIntoNavigationStack() {
+        sut.start()
+
+        XCTAssertTrue(navigationController.pushedViewControllers.contains(detailViewController))
+    }
+
+    func test_whenStart_called_shouldPushWithAnimation() {
+        sut.start()
+
+        XCTAssertEqual(navigationController.pushAnimated.first, true)
+    }
+}

--- a/WallaMarvelTests/Presentation/ListCharactersCoordinatorTests.swift
+++ b/WallaMarvelTests/Presentation/ListCharactersCoordinatorTests.swift
@@ -1,0 +1,71 @@
+import XCTest
+@testable import WallaMarvel
+
+@MainActor
+final class ListCharactersCoordinatorTests: XCTestCase {
+    private let navigationController = NavigationControllerSpy()
+    private let viewController = ListCharactersViewController()
+    private let presenter = ListCharactersPresenterSpy()
+    private lazy var sut = ListCharactersCoordinator(
+        navigationController: navigationController,
+        viewController: viewController,
+        presenter: presenter
+    )
+
+    // MARK: - start
+
+    func test_whenStart_called_shouldPushViewControllerIntoNavigationStack() {
+        sut.start()
+
+        XCTAssertTrue(navigationController.pushedViewControllers.contains(viewController))
+    }
+
+    func test_whenStart_called_shouldPushWithoutAnimation() {
+        sut.start()
+
+        XCTAssertEqual(navigationController.pushAnimated.first, false)
+    }
+
+    func test_whenStart_called_shouldAssignPresenterToViewController() {
+        sut.start()
+
+        XCTAssertTrue(viewController.presenter === presenter as AnyObject)
+    }
+
+    func test_whenStart_called_shouldAssignCoordinatorToViewController() {
+        sut.start()
+
+        XCTAssertTrue(viewController.coordinator === sut)
+    }
+
+    func test_whenStart_called_shouldSetNavigationControllerDelegate() {
+        sut.start()
+
+        XCTAssertTrue(navigationController.delegate === sut)
+    }
+
+    // MARK: - showDetail
+
+    func test_whenShowDetail_called_shouldAddDetailCoordinatorToChildCoordinators() {
+        sut.start()
+        sut.showDetail(for: .fixture())
+
+        XCTAssertEqual(sut.childCoordinators.count, 1)
+        XCTAssertTrue(sut.childCoordinators.first is DetailCharacterCoordinator)
+    }
+
+    func test_whenShowDetail_called_shouldPushDetailViewControllerIntoNavigationStack() {
+        sut.start()
+        sut.showDetail(for: .fixture())
+
+        XCTAssertTrue(navigationController.pushedViewControllers.contains { $0 is DetailCharacterViewController })
+    }
+
+    func test_whenShowDetail_calledMultipleTimes_shouldAccumulateChildCoordinators() {
+        sut.start()
+        sut.showDetail(for: .fixture())
+        sut.showDetail(for: .fixture(id: 2))
+
+        XCTAssertEqual(sut.childCoordinators.count, 2)
+    }
+}

--- a/WallaMarvelTests/Presentation/NavigationCoordinatorTests.swift
+++ b/WallaMarvelTests/Presentation/NavigationCoordinatorTests.swift
@@ -1,0 +1,60 @@
+import XCTest
+@testable import WallaMarvel
+
+@MainActor
+final class NavigationCoordinatorTests: XCTestCase {
+    private let navigationController = UINavigationController()
+    private lazy var sut = NavigationCoordinatorSpy(navigationController: navigationController)
+
+    // MARK: - addChild
+
+    func test_whenAddChild_called_shouldAppendToChildCoordinators() {
+        let child = CoordinatorSpy()
+
+        sut.addChild(child)
+
+        XCTAssertEqual(sut.childCoordinators.count, 1)
+    }
+
+    func test_whenAddChild_called_shouldCallStartOnCoordinator() {
+        let child = CoordinatorSpy()
+
+        sut.addChild(child)
+
+        XCTAssertTrue(child.startCalled)
+    }
+
+    func test_whenAddChild_calledMultipleTimes_shouldAccumulateChildren() {
+        sut.addChild(CoordinatorSpy())
+        sut.addChild(CoordinatorSpy())
+
+        XCTAssertEqual(sut.childCoordinators.count, 2)
+    }
+
+    // MARK: - removeChild
+
+    func test_whenRemoveChild_called_shouldRemoveFromChildCoordinators() {
+        let child = CoordinatorSpy()
+        sut.addChild(child)
+
+        sut.removeChild(child)
+
+        XCTAssertTrue(sut.childCoordinators.isEmpty)
+    }
+
+    func test_whenRemoveChild_calledWithUnknownCoordinator_shouldNotAffectChildCoordinators() {
+        let child = CoordinatorSpy()
+        let other = CoordinatorSpy()
+        sut.addChild(child)
+
+        sut.removeChild(other)
+
+        XCTAssertEqual(sut.childCoordinators.count, 1)
+    }
+}
+
+// MARK: - Concrete subclass for testing (fatalError override)
+
+private final class NavigationCoordinatorSpy: NavigationCoordinator {
+    override var rootViewController: UIViewController { navigationController }
+}

--- a/WallaMarvelTests/Spies/CoordinatorSpy.swift
+++ b/WallaMarvelTests/Spies/CoordinatorSpy.swift
@@ -1,0 +1,18 @@
+import UIKit
+@testable import WallaMarvel
+
+final class CoordinatorSpy: Coordinator {
+    let navigationController: UINavigationController
+    private(set) var rootViewControllerValue: UIViewController
+    var rootViewController: UIViewController { rootViewControllerValue }
+    private(set) var startCalled = false
+
+    init(navigationController: UINavigationController = UINavigationController(), rootViewController: UIViewController = UIViewController()) {
+        self.navigationController = navigationController
+        self.rootViewControllerValue = rootViewController
+    }
+
+    func start() {
+        startCalled = true
+    }
+}

--- a/WallaMarvelTests/Spies/ListCharactersPresenterSpy.swift
+++ b/WallaMarvelTests/Spies/ListCharactersPresenterSpy.swift
@@ -1,0 +1,26 @@
+@testable import WallaMarvel
+
+final class ListCharactersPresenterSpy: ListCharactersPresenterProtocol {
+    var ui: ListCharactersUI?
+    private(set) var screenTitleCalled = false
+    private(set) var getCharactersCalled = false
+    private(set) var loadNextPageCalled = false
+    private(set) var retryNextPageCalled = false
+
+    func screenTitle() -> String {
+        screenTitleCalled = true
+        return "Characters"
+    }
+
+    func getCharacters() async {
+        getCharactersCalled = true
+    }
+
+    func loadNextPage() async {
+        loadNextPageCalled = true
+    }
+
+    func retryNextPage() async {
+        retryNextPageCalled = true
+    }
+}

--- a/WallaMarvelTests/Spies/NavigationControllerSpy.swift
+++ b/WallaMarvelTests/Spies/NavigationControllerSpy.swift
@@ -1,0 +1,12 @@
+import UIKit
+@testable import WallaMarvel
+
+final class NavigationControllerSpy: UINavigationController {
+    private(set) var pushedViewControllers: [UIViewController] = []
+    private(set) var pushAnimated: [Bool] = []
+
+    override func pushViewController(_ viewController: UIViewController, animated: Bool) {
+        pushedViewControllers.append(viewController)
+        pushAnimated.append(animated)
+    }
+}


### PR DESCRIPTION
## Summary
- Introduced Coordinator Pattern across all layers with a clean hierarchy
- Created `Coordinator` protocol as the base contract (`navigationController`, `rootViewController`, `start()`)
- Created `NavigationCoordinator` base class with generic `childCoordinators` management and automatic memory cleanup via `UINavigationControllerDelegate`
- `SceneDelegate` migrated to composition root — sole owner of the dependency graph
- `ListCharactersViewController` decoupled from navigation via `weak var coordinator: ListCharactersCoordinatorProtocol?`
- `DetailCharacterViewController` stub created to satisfy compilation — detail screen implementation is out of scope
- Unit tests added for all coordinators with full spy infrastructure

## Context
- Navigation logic was scattered — `SceneDelegate` knew how to build screens, `ListCharactersViewController` knew where to navigate
- `didSelectRowAt` had a `// TODO: add navigation` comment with no defined owner
- No mechanism existed to manage coordinator lifecycle, leading to potential memory leaks on future detail flows

## Evidences

<img width="6644" height="6345" alt="image" src="https://github.com/user-attachments/assets/90a606fa-7a87-4b4b-b5df-09df00ea8559" />


## Changes
- `Coordinator.swift` — protocol with `navigationController`, `rootViewController`, `@MainActor start()`
- `NavigationCoordinator.swift` — `NSObject` base class: `childCoordinators`, `addChild`, `removeChild` (`@MainActor`), `UINavigationControllerDelegate` for automatic child cleanup using `rootViewController` identity
- `AppCoordinator.swift` — root coordinator, owns `UIWindow` and `UINavigationController`, receives `Coordinator` protocol (not concrete) for testability
- `ListCharactersCoordinator.swift` — wires list screen, sets `navigationController.delegate`, navigates to detail via `showDetail(for:)`
- `DetailCharacterCoordinator.swift` — receives `DetailCharacterViewController` via `init`, pushes on `start()`
- `DetailCharacterViewController.swift` — stub, receives `Character` via `init`
- `SceneDelegate.swift` — now only builds the dependency graph and calls `appCoordinator.start()`
- `ListCharactersViewController.swift` — added `weak var coordinator`, `didSelectRowAt` delegates to coordinator

## Tests
**What was tested:**
- `NavigationCoordinator`: `addChild` appends and calls `start()`; `removeChild` removes only the correct child
- `AppCoordinator`: `start()` sets `window.rootViewController`; calls `start()` on root coordinator
- `ListCharactersCoordinator`: push on `start()`; assigns presenter and coordinator to VC; sets delegate; `showDetail` creates `DetailCharacterCoordinator` and pushes detail VC
- `DetailCharacterCoordinator`: `rootViewController` is the detail VC; push with animation on `start()`

**How it was validated:**
- Spy pattern: `CoordinatorSpy`, `NavigationControllerSpy`, `ListCharactersPresenterSpy`
- All existing tests remain green — no business logic was changed