### PR TITLE
REFACTOR:[WP-10] Improve APIClient with APIRequest pattern and APIEndpoint enum

### DIFF
--- a/WallaMarvel.xcodeproj/project.pbxproj
+++ b/WallaMarvel.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0D6A93A4DA0047F880E557F5 /* AppCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81E290EAA75A481AABB9C916 /* AppCoordinatorTests.swift */; };
+		11C665E1A0434754BC325478 /* NavigationCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F50F999FDC134F2FBC1AE674 /* NavigationCoordinatorTests.swift */; };
 		1A0E3A992862F7E200132FCB /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A0E3A982862F7E200132FCB /* AppDelegate.swift */; };
 		1A0E3A9B2862F7E200132FCB /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A0E3A9A2862F7E200132FCB /* SceneDelegate.swift */; };
 		1A0E3A9D2862F7E200132FCB /* ListCharactersViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A0E3A9C2862F7E200132FCB /* ListCharactersViewController.swift */; };
@@ -52,24 +54,26 @@
 		1AE537D32F7E0BE8008BABB4 /* Location+fixture.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AE537D22F7E0BE8008BABB4 /* Location+fixture.swift */; };
 		1AE537D52F7E0BEC008BABB4 /* Thumbnail+fixture.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AE537D42F7E0BEC008BABB4 /* Thumbnail+fixture.swift */; };
 		1AE537D72F7E0BFA008BABB4 /* CharacterDataModel+fixture.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AE537D62F7E0BFA008BABB4 /* CharacterDataModel+fixture.swift */; };
+		32E1A29D39CE4052BCCBD93D /* DetailCharacterViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DF9F54FF44D48C59E7A512B /* DetailCharacterViewController.swift */; };
+		4FDB7E18878F4109925B5550 /* DetailCharacterCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E58D2A6FF494563B81B0AB6 /* DetailCharacterCoordinator.swift */; };
+		5412BD73593E53FEBAD5C932 /* GetCharactersRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21101AD5D5DDC7F54FB4FCB7 /* GetCharactersRequest.swift */; };
+		62A64D24FBF148FC9C96B7B6 /* ListCharactersPresenterSpy.swift in Sources */ = {isa = PBXBuildFile; fileRef = F999718C32A14F03B57291BA /* ListCharactersPresenterSpy.swift */; };
 		6FF50D79AFADE4D4FA3E6F4A /* AppErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D28C8FF45D193ADF868F043 /* AppErrorTests.swift */; };
+		70FE356A1D2E46CF8F23A409 /* AppCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34806026B7C74446890FEAAA /* AppCoordinator.swift */; };
+		84B2CDB4B18C4BCFB1E2DF7C /* ListCharactersCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 394E89142B384D20ABA450E9 /* ListCharactersCoordinatorTests.swift */; };
+		9941029E5E8B4E1C841B9595 /* CoordinatorSpy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 361D2986EC92485BBE27626D /* CoordinatorSpy.swift */; };
 		A66389F32DCE202500466318 /* Kingfisher in Frameworks */ = {isa = PBXBuildFile; productRef = A66389F22DCE202500466318 /* Kingfisher */; };
+		AAA33E7B86424403B41EE494 /* NavigationControllerSpy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62812BA212B04EA0A3332DAF /* NavigationControllerSpy.swift */; };
+		BBB2C3D4E5F6789012345678 /* NavigationCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAB1C2D3E4F567890A1B2C3D /* NavigationCoordinator.swift */; };
+		BCF398D17CBB47258DAB5072 /* DetailCharacterCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DD07A1D63744C428AD00498 /* DetailCharacterCoordinatorTests.swift */; };
 		C0E34B0FEA5F574586DAEE37 /* AppErrorMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 098896F8E8ADBCEA320C7B48 /* AppErrorMapper.swift */; };
+		C1E036C813C242EE8DC3E642 /* ListCharactersCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B8FD56AF9DD44179F23488E /* ListCharactersCoordinator.swift */; };
+		C32DE32BD594964F2E9FABEC /* APIRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E6BA011CE2164EC0FC8C895 /* APIRequest.swift */; };
+		C3E25A42127D5A24366898FB /* GetCharactersRequestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8295D9DD7AAF68DE1B56F646 /* GetCharactersRequestTests.swift */; };
+		DC362878A9F819C902162AD5 /* APIEndpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2444602288BBE8E4976DC45 /* APIEndpoint.swift */; };
+		ECEE354E22C34945A90688BC /* Coordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFDCAA3E5318472B9C43F70A /* Coordinator.swift */; };
 		F585F2C321223DDD15051939 /* AppError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DCD5856E0C7CEDDA14C48D5 /* AppError.swift */; };
 		F8958390974A92B22B51A0CE /* AppErrorMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7331CFD7344EAA013BAF60E8 /* AppErrorMapperTests.swift */; };
-		ECEE354E22C34945A90688BC /* Coordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFDCAA3E5318472B9C43F70A /* Coordinator.swift */; };
-		70FE356A1D2E46CF8F23A409 /* AppCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34806026B7C74446890FEAAA /* AppCoordinator.swift */; };
-		C1E036C813C242EE8DC3E642 /* ListCharactersCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B8FD56AF9DD44179F23488E /* ListCharactersCoordinator.swift */; };
-		4FDB7E18878F4109925B5550 /* DetailCharacterCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E58D2A6FF494563B81B0AB6 /* DetailCharacterCoordinator.swift */; };
-		32E1A29D39CE4052BCCBD93D /* DetailCharacterViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DF9F54FF44D48C59E7A512B /* DetailCharacterViewController.swift */; };
-		BBB2C3D4E5F6789012345678 /* NavigationCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAB1C2D3E4F567890A1B2C3D /* NavigationCoordinator.swift */; };
-		9941029E5E8B4E1C841B9595 /* CoordinatorSpy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 361D2986EC92485BBE27626D /* CoordinatorSpy.swift */; };
-		AAA33E7B86424403B41EE494 /* NavigationControllerSpy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62812BA212B04EA0A3332DAF /* NavigationControllerSpy.swift */; };
-		62A64D24FBF148FC9C96B7B6 /* ListCharactersPresenterSpy.swift in Sources */ = {isa = PBXBuildFile; fileRef = F999718C32A14F03B57291BA /* ListCharactersPresenterSpy.swift */; };
-		11C665E1A0434754BC325478 /* NavigationCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F50F999FDC134F2FBC1AE674 /* NavigationCoordinatorTests.swift */; };
-		0D6A93A4DA0047F880E557F5 /* AppCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81E290EAA75A481AABB9C916 /* AppCoordinatorTests.swift */; };
-		84B2CDB4B18C4BCFB1E2DF7C /* ListCharactersCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 394E89142B384D20ABA450E9 /* ListCharactersCoordinatorTests.swift */; };
-		BCF398D17CBB47258DAB5072 /* DetailCharacterCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DD07A1D63744C428AD00498 /* DetailCharacterCoordinatorTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -141,21 +145,25 @@
 		1AE537D42F7E0BEC008BABB4 /* Thumbnail+fixture.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Thumbnail+fixture.swift"; sourceTree = "<group>"; };
 		1AE537D62F7E0BFA008BABB4 /* CharacterDataModel+fixture.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CharacterDataModel+fixture.swift"; sourceTree = "<group>"; };
 		1DCD5856E0C7CEDDA14C48D5 /* AppError.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AppError.swift; path = WallaMarvel/Domain/Errors/AppError.swift; sourceTree = "<group>"; };
-		7331CFD7344EAA013BAF60E8 /* AppErrorMapperTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AppErrorMapperTests.swift; sourceTree = "<group>"; };
-		9D28C8FF45D193ADF868F043 /* AppErrorTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AppErrorTests.swift; sourceTree = "<group>"; };
-		CFDCAA3E5318472B9C43F70A /* Coordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Coordinator.swift; sourceTree = "<group>"; };
-		34806026B7C74446890FEAAA /* AppCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppCoordinator.swift; sourceTree = "<group>"; };
-		9B8FD56AF9DD44179F23488E /* ListCharactersCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListCharactersCoordinator.swift; sourceTree = "<group>"; };
-		5E58D2A6FF494563B81B0AB6 /* DetailCharacterCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailCharacterCoordinator.swift; sourceTree = "<group>"; };
-		3DF9F54FF44D48C59E7A512B /* DetailCharacterViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailCharacterViewController.swift; sourceTree = "<group>"; };
-		AAB1C2D3E4F567890A1B2C3D /* NavigationCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationCoordinator.swift; sourceTree = "<group>"; };
-		361D2986EC92485BBE27626D /* CoordinatorSpy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoordinatorSpy.swift; sourceTree = "<group>"; };
-		62812BA212B04EA0A3332DAF /* NavigationControllerSpy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationControllerSpy.swift; sourceTree = "<group>"; };
-		F999718C32A14F03B57291BA /* ListCharactersPresenterSpy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListCharactersPresenterSpy.swift; sourceTree = "<group>"; };
-		F50F999FDC134F2FBC1AE674 /* NavigationCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationCoordinatorTests.swift; sourceTree = "<group>"; };
-		81E290EAA75A481AABB9C916 /* AppCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppCoordinatorTests.swift; sourceTree = "<group>"; };
-		394E89142B384D20ABA450E9 /* ListCharactersCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListCharactersCoordinatorTests.swift; sourceTree = "<group>"; };
 		1DD07A1D63744C428AD00498 /* DetailCharacterCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailCharacterCoordinatorTests.swift; sourceTree = "<group>"; };
+		1E6BA011CE2164EC0FC8C895 /* APIRequest.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = APIRequest.swift; path = Requests/APIRequest.swift; sourceTree = "<group>"; };
+		21101AD5D5DDC7F54FB4FCB7 /* GetCharactersRequest.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = GetCharactersRequest.swift; path = Requests/GetCharactersRequest.swift; sourceTree = "<group>"; };
+		34806026B7C74446890FEAAA /* AppCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppCoordinator.swift; sourceTree = "<group>"; };
+		361D2986EC92485BBE27626D /* CoordinatorSpy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoordinatorSpy.swift; sourceTree = "<group>"; };
+		394E89142B384D20ABA450E9 /* ListCharactersCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListCharactersCoordinatorTests.swift; sourceTree = "<group>"; };
+		3DF9F54FF44D48C59E7A512B /* DetailCharacterViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailCharacterViewController.swift; sourceTree = "<group>"; };
+		5E58D2A6FF494563B81B0AB6 /* DetailCharacterCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailCharacterCoordinator.swift; sourceTree = "<group>"; };
+		62812BA212B04EA0A3332DAF /* NavigationControllerSpy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationControllerSpy.swift; sourceTree = "<group>"; };
+		7331CFD7344EAA013BAF60E8 /* AppErrorMapperTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AppErrorMapperTests.swift; sourceTree = "<group>"; };
+		81E290EAA75A481AABB9C916 /* AppCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppCoordinatorTests.swift; sourceTree = "<group>"; };
+		8295D9DD7AAF68DE1B56F646 /* GetCharactersRequestTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GetCharactersRequestTests.swift; sourceTree = "<group>"; };
+		9B8FD56AF9DD44179F23488E /* ListCharactersCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListCharactersCoordinator.swift; sourceTree = "<group>"; };
+		9D28C8FF45D193ADF868F043 /* AppErrorTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AppErrorTests.swift; sourceTree = "<group>"; };
+		A2444602288BBE8E4976DC45 /* APIEndpoint.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = APIEndpoint.swift; path = Requests/APIEndpoint.swift; sourceTree = "<group>"; };
+		AAB1C2D3E4F567890A1B2C3D /* NavigationCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationCoordinator.swift; sourceTree = "<group>"; };
+		CFDCAA3E5318472B9C43F70A /* Coordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Coordinator.swift; sourceTree = "<group>"; };
+		F50F999FDC134F2FBC1AE674 /* NavigationCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationCoordinatorTests.swift; sourceTree = "<group>"; };
+		F999718C32A14F03B57291BA /* ListCharactersPresenterSpy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListCharactersPresenterSpy.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -283,6 +291,7 @@
 				1A821ED2286302D40024D397 /* DataModel */,
 				1A821ECA2862FF910024D397 /* Helpers */,
 				1AA67B9A2F7E1EA8002C7F2E /* Mapping */,
+				97DF30D59FE87B76C0592E10 /* Requests */,
 			);
 			path = Data;
 			sourceTree = "<group>";
@@ -315,18 +324,6 @@
 				1A821EC42862FD470024D397 /* ListCharacter */,
 			);
 			path = Presentation;
-			sourceTree = "<group>";
-		};
-		9F11DE6BE37B4086AF398B8F /* Coordinators */ = {
-			isa = PBXGroup;
-			children = (
-				CFDCAA3E5318472B9C43F70A /* Coordinator.swift */,
-				AAB1C2D3E4F567890A1B2C3D /* NavigationCoordinator.swift */,
-				34806026B7C74446890FEAAA /* AppCoordinator.swift */,
-				9B8FD56AF9DD44179F23488E /* ListCharactersCoordinator.swift */,
-				5E58D2A6FF494563B81B0AB6 /* DetailCharacterCoordinator.swift */,
-			);
-			path = Coordinators;
 			sourceTree = "<group>";
 		};
 		1AA67B832F7E13FE002C7F2E /* Domain */ = {
@@ -363,6 +360,7 @@
 				1AA67B9F2F7E1F82002C7F2E /* CharacterDataModelMappingTests.swift */,
 				1AA67B932F7E1525002C7F2E /* CharacterDataSourceTests.swift */,
 				7331CFD7344EAA013BAF60E8 /* AppErrorMapperTests.swift */,
+				8295D9DD7AAF68DE1B56F646 /* GetCharactersRequestTests.swift */,
 			);
 			path = Data;
 			sourceTree = "<group>";
@@ -454,6 +452,28 @@
 				360E950CD5EEA36D950549EF /* ErrorMapping */,
 			);
 			name = Data;
+			sourceTree = "<group>";
+		};
+		97DF30D59FE87B76C0592E10 /* Requests */ = {
+			isa = PBXGroup;
+			children = (
+				1E6BA011CE2164EC0FC8C895 /* APIRequest.swift */,
+				21101AD5D5DDC7F54FB4FCB7 /* GetCharactersRequest.swift */,
+				A2444602288BBE8E4976DC45 /* APIEndpoint.swift */,
+			);
+			name = Requests;
+			sourceTree = "<group>";
+		};
+		9F11DE6BE37B4086AF398B8F /* Coordinators */ = {
+			isa = PBXGroup;
+			children = (
+				CFDCAA3E5318472B9C43F70A /* Coordinator.swift */,
+				AAB1C2D3E4F567890A1B2C3D /* NavigationCoordinator.swift */,
+				34806026B7C74446890FEAAA /* AppCoordinator.swift */,
+				9B8FD56AF9DD44179F23488E /* ListCharactersCoordinator.swift */,
+				5E58D2A6FF494563B81B0AB6 /* DetailCharacterCoordinator.swift */,
+			);
+			path = Coordinators;
 			sourceTree = "<group>";
 		};
 		A6E019FA656C27733E0A999D /* Domain */ = {
@@ -625,6 +645,9 @@
 				4FDB7E18878F4109925B5550 /* DetailCharacterCoordinator.swift in Sources */,
 				32E1A29D39CE4052BCCBD93D /* DetailCharacterViewController.swift in Sources */,
 				BBB2C3D4E5F6789012345678 /* NavigationCoordinator.swift in Sources */,
+				C32DE32BD594964F2E9FABEC /* APIRequest.swift in Sources */,
+				5412BD73593E53FEBAD5C932 /* GetCharactersRequest.swift in Sources */,
+				DC362878A9F819C902162AD5 /* APIEndpoint.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -662,6 +685,7 @@
 				0D6A93A4DA0047F880E557F5 /* AppCoordinatorTests.swift in Sources */,
 				84B2CDB4B18C4BCFB1E2DF7C /* ListCharactersCoordinatorTests.swift in Sources */,
 				BCF398D17CBB47258DAB5072 /* DetailCharacterCoordinatorTests.swift in Sources */,
+				C3E25A42127D5A24366898FB /* GetCharactersRequestTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/WallaMarvel.xcodeproj/project.pbxproj
+++ b/WallaMarvel.xcodeproj/project.pbxproj
@@ -22,7 +22,6 @@
 		1A3B732A286AE195007BF626 /* ListCharactersAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A3B7329286AE195007BF626 /* ListCharactersAdapter.swift */; };
 		1A7B9BBF286D81B600EBC1A6 /* Thumbnail.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A7B9BBE286D81B600EBC1A6 /* Thumbnail.swift */; };
 		1A821EC92862FE3C0024D397 /* APIClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A821EC82862FE3C0024D397 /* APIClient.swift */; };
-		1A821ECC2862FF990024D397 /* String+MD5.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A821ECB2862FF990024D397 /* String+MD5.swift */; };
 		1A821ED4286302EC0024D397 /* CharacterResponseDataModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A821ED3286302EC0024D397 /* CharacterResponseDataModel.swift */; };
 		1A821ED6286305590024D397 /* CharacterDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A821ED5286305590024D397 /* CharacterDataSource.swift */; };
 		1A821ED82863081A0024D397 /* CharacterRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A821ED72863081A0024D397 /* CharacterRepository.swift */; };
@@ -112,7 +111,6 @@
 		1A3B7329286AE195007BF626 /* ListCharactersAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListCharactersAdapter.swift; sourceTree = "<group>"; };
 		1A7B9BBE286D81B600EBC1A6 /* Thumbnail.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Thumbnail.swift; sourceTree = "<group>"; };
 		1A821EC82862FE3C0024D397 /* APIClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIClient.swift; sourceTree = "<group>"; };
-		1A821ECB2862FF990024D397 /* String+MD5.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+MD5.swift"; sourceTree = "<group>"; };
 		1A821ED3286302EC0024D397 /* CharacterResponseDataModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CharacterResponseDataModel.swift; sourceTree = "<group>"; };
 		1A821ED5286305590024D397 /* CharacterDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CharacterDataSource.swift; sourceTree = "<group>"; };
 		1A821ED72863081A0024D397 /* CharacterRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CharacterRepository.swift; sourceTree = "<group>"; };
@@ -299,7 +297,6 @@
 		1A821ECA2862FF910024D397 /* Helpers */ = {
 			isa = PBXGroup;
 			children = (
-				1A821ECB2862FF990024D397 /* String+MD5.swift */,
 			);
 			path = Helpers;
 			sourceTree = "<group>";
@@ -624,7 +621,6 @@
 				1AE537C22F7E04A9008BABB4 /* Location.swift in Sources */,
 				1AC0347F2863214900E93178 /* GetCharacters.swift in Sources */,
 				1A0E3A992862F7E200132FCB /* AppDelegate.swift in Sources */,
-				1A821ECC2862FF990024D397 /* String+MD5.swift in Sources */,
 				1A821ED6286305590024D397 /* CharacterDataSource.swift in Sources */,
 				1A3B732A286AE195007BF626 /* ListCharactersAdapter.swift in Sources */,
 				1A7B9BBF286D81B600EBC1A6 /* Thumbnail.swift in Sources */,

--- a/WallaMarvel/Data/APIClient.swift
+++ b/WallaMarvel/Data/APIClient.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 protocol APIClientProtocol {
-    func getCharacters(page: Int) async throws -> CharacterDataContainer
+    func request<T: Decodable>(_ request: any APIRequest) async throws -> T
 }
 
 final class APIClient: APIClientProtocol {
@@ -19,14 +19,8 @@ final class APIClient: APIClientProtocol {
         self.retryDelay = retryDelay
     }
 
-    func getCharacters(page: Int) async throws -> CharacterDataContainer {
-        var components = URLComponents(string: "https://rickandmortyapi.com/api/character")
-        components?.queryItems = [URLQueryItem(name: "page", value: String(page))]
-
-        guard let url = components?.url else {
-            throw AppError.invalidData("Invalid API endpoint URL")
-        }
-
+    func request<T: Decodable>(_ request: any APIRequest) async throws -> T {
+        let url = try request.makeURL()
         var lastError: Error?
         for attempt in 1...maxRetries {
             do {
@@ -38,7 +32,7 @@ final class APIClient: APIClientProtocol {
                     }
                 }
 
-                return try JSONDecoder().decode(CharacterDataContainer.self, from: data)
+                return try JSONDecoder().decode(T.self, from: data)
             } catch {
                 lastError = error
                 if attempt < maxRetries {
@@ -47,6 +41,9 @@ final class APIClient: APIClientProtocol {
             }
         }
 
-        throw lastError!
+        guard let lastError else {
+            throw AppError.unknown("Request failed with no recorded error")
+        }
+        throw lastError
     }
 }

--- a/WallaMarvel/Data/CharacterDataSource.swift
+++ b/WallaMarvel/Data/CharacterDataSource.swift
@@ -13,7 +13,7 @@ final class CharacterDataSource: CharacterDataSourceProtocol {
     
     func getCharacters(page: Int) async throws -> CharacterDataContainer {
         do {
-            return try await apiClient.getCharacters(page: page)
+            return try await apiClient.request(GetCharactersRequest(page: page))
         } catch {
             throw AppErrorMapper.map(error)
         }

--- a/WallaMarvel/Data/Helpers/String+MD5.swift
+++ b/WallaMarvel/Data/Helpers/String+MD5.swift
@@ -1,9 +1,0 @@
-import Foundation
-import CryptoKit
-
-extension String {
-    var md5: String {
-        let digest = Insecure.MD5.hash(data: self.data(using: .utf8) ?? Data())
-        return digest.map { .init(format: "%02hhx", $0) }.joined()
-    }
-}

--- a/WallaMarvel/Data/Requests/APIEndpoint.swift
+++ b/WallaMarvel/Data/Requests/APIEndpoint.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+enum APIEndpoint {
+    static let baseURL = "https://rickandmortyapi.com"
+
+    enum Path: String {
+        case characters = "/api/character"
+        case episode    = "/api/episode"
+    }
+}

--- a/WallaMarvel/Data/Requests/APIRequest.swift
+++ b/WallaMarvel/Data/Requests/APIRequest.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+protocol APIRequest {
+    func makeURL() throws -> URL
+}

--- a/WallaMarvel/Data/Requests/GetCharactersRequest.swift
+++ b/WallaMarvel/Data/Requests/GetCharactersRequest.swift
@@ -1,0 +1,14 @@
+import Foundation
+
+struct GetCharactersRequest: APIRequest {
+    let page: Int
+
+    func makeURL() throws -> URL {
+        var components = URLComponents(string: APIEndpoint.baseURL + APIEndpoint.Path.characters.rawValue)
+        components?.queryItems = [URLQueryItem(name: "page", value: String(page))]
+        guard let url = components?.url else {
+            throw AppError.invalidData("Invalid characters endpoint URL")
+        }
+        return url
+    }
+}

--- a/WallaMarvelTests/Data/APIClientTests.swift
+++ b/WallaMarvelTests/Data/APIClientTests.swift
@@ -2,8 +2,339 @@ import XCTest
 @testable import WallaMarvel
 
 final class APIClientTests: XCTestCase {
-    private let baseEndpoint = URL(string: "https://rickandmortyapi.com/api/character")
+    private let targetURL = URL(string: "https://rickandmortyapi.com/api/character?page=1")!
     private var session: URLSession!
+
+    override func setUp() {
+        super.setUp()
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [URLProtocolStub.self]
+        session = URLSession(configuration: configuration)
+    }
+
+    override func tearDown() {
+        URLProtocolStub.stopIntercepting()
+        session = nil
+        super.tearDown()
+    }
+
+    // MARK: - URL passthrough
+
+    func test_whenRequest_called_shouldUseURLFromRequest() async throws {
+        var requestedURL: URL?
+        let data = makeValidResponseData()
+        let response = HTTPURLResponse(url: targetURL, statusCode: 200, httpVersion: nil, headerFields: nil)
+        URLProtocolStub.startIntercepting(with: .init(data: data, response: response, error: nil, requestObserver: { request in
+            requestedURL = request.url
+        }))
+
+        let sut = APIClient(session: session)
+        let _: CharacterDataContainer = try await sut.request(TestAPIRequest(url: targetURL))
+
+        XCTAssertEqual(requestedURL, targetURL)
+    }
+
+    // MARK: - Decoding
+
+    func test_whenRequest_succeeds_shouldReturnDecodedModel() async throws {
+        let data = makeValidResponseData()
+        let response = HTTPURLResponse(url: targetURL, statusCode: 200, httpVersion: nil, headerFields: nil)
+        URLProtocolStub.startIntercepting(with: .init(data: data, response: response, error: nil, requestObserver: nil))
+
+        let sut = APIClient(session: session)
+        let result: CharacterDataContainer = try await sut.request(TestAPIRequest(url: targetURL))
+
+        XCTAssertEqual(result.results.count, 1)
+    }
+
+    // MARK: - Error handling
+
+    func test_whenRequest_sessionReturnsError_shouldThrow() async {
+        URLProtocolStub.startIntercepting(with: .init(data: nil, response: nil, error: TestError.any, requestObserver: nil))
+
+        let sut = APIClient(session: session, maxRetries: 1, retryDelay: 0)
+
+        do {
+            let _: CharacterDataContainer = try await sut.request(TestAPIRequest(url: targetURL))
+            XCTFail("Expected error to be thrown")
+        } catch {
+            XCTAssertTrue(true)
+        }
+    }
+
+    func test_whenRequest_receivesInvalidData_shouldThrow() async {
+        let response = HTTPURLResponse(url: targetURL, statusCode: 200, httpVersion: nil, headerFields: nil)
+        URLProtocolStub.startIntercepting(with: .init(data: Data("invalid".utf8), response: response, error: nil, requestObserver: nil))
+
+        let sut = APIClient(session: session, maxRetries: 1, retryDelay: 0)
+
+        do {
+            let _: CharacterDataContainer = try await sut.request(TestAPIRequest(url: targetURL))
+            XCTFail("Expected error to be thrown")
+        } catch {
+            XCTAssertTrue(true)
+        }
+    }
+
+    // MARK: - Retry
+
+    func test_whenRequest_failsOnFirstAttempt_shouldRetryAndSucceed() async throws {
+        let successData = makeValidResponseData()
+        let successResponse = HTTPURLResponse(url: targetURL, statusCode: 200, httpVersion: nil, headerFields: nil)
+
+        URLProtocolStub.startIntercepting(withSequence: [
+            .init(data: nil, response: nil, error: URLError(.networkConnectionLost), requestObserver: nil),
+            .init(data: successData, response: successResponse, error: nil, requestObserver: nil)
+        ])
+
+        let sut = APIClient(session: session, maxRetries: 2, retryDelay: 0)
+        let result: CharacterDataContainer = try await sut.request(TestAPIRequest(url: targetURL))
+
+        XCTAssertEqual(result.results.count, 1)
+    }
+
+    func test_whenRequest_failsAllAttempts_shouldThrowLastError() async {
+        var requestCount = 0
+        URLProtocolStub.startIntercepting(withSequence: [
+            .init(data: nil, response: nil, error: URLError(.networkConnectionLost), requestObserver: { _ in requestCount += 1 }),
+            .init(data: nil, response: nil, error: URLError(.networkConnectionLost), requestObserver: { _ in requestCount += 1 }),
+            .init(data: nil, response: nil, error: URLError(.networkConnectionLost), requestObserver: { _ in requestCount += 1 })
+        ])
+
+        let sut = APIClient(session: session, maxRetries: 3, retryDelay: 0)
+
+        do {
+            let _: CharacterDataContainer = try await sut.request(TestAPIRequest(url: targetURL))
+            XCTFail("Expected error to be thrown")
+        } catch {
+            XCTAssertEqual(requestCount, 3)
+        }
+    }
+
+    func test_whenRequest_succeedsOnFirstAttempt_shouldNotRetry() async throws {
+        var requestCount = 0
+        let successData = makeValidResponseData()
+        let successResponse = HTTPURLResponse(url: targetURL, statusCode: 200, httpVersion: nil, headerFields: nil)
+
+        URLProtocolStub.startIntercepting(withSequence: [
+            .init(data: successData, response: successResponse, error: nil, requestObserver: { _ in requestCount += 1 })
+        ])
+
+        let sut = APIClient(session: session, maxRetries: 3, retryDelay: 0)
+        let _: CharacterDataContainer = try await sut.request(TestAPIRequest(url: targetURL))
+
+        XCTAssertEqual(requestCount, 1)
+    }
+
+    // MARK: - Helpers
+
+    private func makeValidResponseData() -> Data {
+        let json = """
+        {
+            "info": {
+                "count": 1,
+                "pages": 1,
+                "next": null,
+                "prev": null
+            },
+            "results": [
+                {
+                    "id": 1,
+                    "name": "Rick Sanchez",
+                    "status": "Alive",
+                    "species": "Human",
+                    "type": "",
+                    "gender": "Male",
+                    "origin": {
+                        "name": "Earth",
+                        "url": "https://example.com/origin/1"
+                    },
+                    "location": {
+                        "name": "Earth",
+                        "url": "https://example.com/location/1"
+                    },
+                    "image": "https://example.com/character/1.png",
+                    "episode": [
+                        "https://example.com/episode/1"
+                    ],
+                    "url": "https://example.com/character/1",
+                    "created": "2020-01-01T00:00:00.000Z"
+                }
+            ]
+        }
+        """
+        return Data(json.utf8)
+    }
+}
+
+// MARK: - Test helpers
+
+private struct TestAPIRequest: APIRequest {
+    let url: URL
+    func makeURL() throws -> URL { url }
+}
+
+    override func setUp() {
+        super.setUp()
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [URLProtocolStub.self]
+        session = URLSession(configuration: configuration)
+    }
+
+    override func tearDown() {
+        URLProtocolStub.stopIntercepting()
+        session = nil
+        super.tearDown()
+    }
+
+    // MARK: - URL passthrough
+
+    func test_whenRequest_called_shouldUseProvidedURL() async throws {
+        var requestedURL: URL?
+        let data = makeValidResponseData()
+        let response = HTTPURLResponse(url: targetURL, statusCode: 200, httpVersion: nil, headerFields: nil)
+        URLProtocolStub.startIntercepting(with: .init(data: data, response: response, error: nil, requestObserver: { request in
+            requestedURL = request.url
+        }))
+
+        let sut = APIClient(session: session)
+        let _: CharacterDataContainer = try await sut.request(targetURL)
+
+        XCTAssertEqual(requestedURL, targetURL)
+    }
+
+    // MARK: - Decoding
+
+    func test_whenRequest_succeeds_shouldReturnDecodedModel() async throws {
+        let data = makeValidResponseData()
+        let response = HTTPURLResponse(url: targetURL, statusCode: 200, httpVersion: nil, headerFields: nil)
+        URLProtocolStub.startIntercepting(with: .init(data: data, response: response, error: nil, requestObserver: nil))
+
+        let sut = APIClient(session: session)
+        let result: CharacterDataContainer = try await sut.request(targetURL)
+
+        XCTAssertEqual(result.results.count, 1)
+    }
+
+    // MARK: - Error handling
+
+    func test_whenRequest_sessionReturnsError_shouldThrow() async {
+        URLProtocolStub.startIntercepting(with: .init(data: nil, response: nil, error: TestError.any, requestObserver: nil))
+
+        let sut = APIClient(session: session, maxRetries: 1, retryDelay: 0)
+
+        do {
+            let _: CharacterDataContainer = try await sut.request(targetURL)
+            XCTFail("Expected error to be thrown")
+        } catch {
+            XCTAssertTrue(true)
+        }
+    }
+
+    func test_whenRequest_receivesInvalidData_shouldThrow() async {
+        let response = HTTPURLResponse(url: targetURL, statusCode: 200, httpVersion: nil, headerFields: nil)
+        URLProtocolStub.startIntercepting(with: .init(data: Data("invalid".utf8), response: response, error: nil, requestObserver: nil))
+
+        let sut = APIClient(session: session, maxRetries: 1, retryDelay: 0)
+
+        do {
+            let _: CharacterDataContainer = try await sut.request(targetURL)
+            XCTFail("Expected error to be thrown")
+        } catch {
+            XCTAssertTrue(true)
+        }
+    }
+
+    // MARK: - Retry
+
+    func test_whenRequest_failsOnFirstAttempt_shouldRetryAndSucceed() async throws {
+        let successData = makeValidResponseData()
+        let successResponse = HTTPURLResponse(url: targetURL, statusCode: 200, httpVersion: nil, headerFields: nil)
+
+        URLProtocolStub.startIntercepting(withSequence: [
+            .init(data: nil, response: nil, error: URLError(.networkConnectionLost), requestObserver: nil),
+            .init(data: successData, response: successResponse, error: nil, requestObserver: nil)
+        ])
+
+        let sut = APIClient(session: session, maxRetries: 2, retryDelay: 0)
+        let result: CharacterDataContainer = try await sut.request(targetURL)
+
+        XCTAssertEqual(result.results.count, 1)
+    }
+
+    func test_whenRequest_failsAllAttempts_shouldThrowLastError() async {
+        var requestCount = 0
+        URLProtocolStub.startIntercepting(withSequence: [
+            .init(data: nil, response: nil, error: URLError(.networkConnectionLost), requestObserver: { _ in requestCount += 1 }),
+            .init(data: nil, response: nil, error: URLError(.networkConnectionLost), requestObserver: { _ in requestCount += 1 }),
+            .init(data: nil, response: nil, error: URLError(.networkConnectionLost), requestObserver: { _ in requestCount += 1 })
+        ])
+
+        let sut = APIClient(session: session, maxRetries: 3, retryDelay: 0)
+
+        do {
+            let _: CharacterDataContainer = try await sut.request(targetURL)
+            XCTFail("Expected error to be thrown")
+        } catch {
+            XCTAssertEqual(requestCount, 3)
+        }
+    }
+
+    func test_whenRequest_succeedsOnFirstAttempt_shouldNotRetry() async throws {
+        var requestCount = 0
+        let successData = makeValidResponseData()
+        let successResponse = HTTPURLResponse(url: targetURL, statusCode: 200, httpVersion: nil, headerFields: nil)
+
+        URLProtocolStub.startIntercepting(withSequence: [
+            .init(data: successData, response: successResponse, error: nil, requestObserver: { _ in requestCount += 1 })
+        ])
+
+        let sut = APIClient(session: session, maxRetries: 3, retryDelay: 0)
+        let _: CharacterDataContainer = try await sut.request(targetURL)
+
+        XCTAssertEqual(requestCount, 1)
+    }
+
+    // MARK: - Helpers
+
+    private func makeValidResponseData() -> Data {
+        let json = """
+        {
+            "info": {
+                "count": 1,
+                "pages": 1,
+                "next": null,
+                "prev": null
+            },
+            "results": [
+                {
+                    "id": 1,
+                    "name": "Rick Sanchez",
+                    "status": "Alive",
+                    "species": "Human",
+                    "type": "",
+                    "gender": "Male",
+                    "origin": {
+                        "name": "Earth",
+                        "url": "https://example.com/origin/1"
+                    },
+                    "location": {
+                        "name": "Earth",
+                        "url": "https://example.com/location/1"
+                    },
+                    "image": "https://example.com/character/1.png",
+                    "episode": [
+                        "https://example.com/episode/1"
+                    ],
+                    "url": "https://example.com/character/1",
+                    "created": "2020-01-01T00:00:00.000Z"
+                }
+            ]
+        }
+        """
+        return Data(json.utf8)
+    }
+}
 
     override func setUp() {
         super.setUp()

--- a/WallaMarvelTests/Data/CharacterDataSourceTests.swift
+++ b/WallaMarvelTests/Data/CharacterDataSourceTests.swift
@@ -5,27 +5,29 @@ final class CharacterDataSourceTests: XCTestCase {
     private let apiClientSpy = APIClientSpy()
     private lazy var sut = CharacterDataSource(apiClient: apiClientSpy)
 
+    // MARK: - request delegation
+
     func test_whenGetCharacters_called_shouldCallAPIClient() async throws {
+        apiClientSpy.resultProvider = { _ in CharacterDataContainer.fixture() }
+
         _ = try await sut.getCharacters(page: 1)
 
-        XCTAssertTrue(apiClientSpy.getCharactersCalled)
+        XCTAssertTrue(apiClientSpy.requestCalled)
     }
 
-    func test_whenGetCharacters_called_shouldPassPageToAPIClient() async throws {
-        _ = try await sut.getCharacters(page: 2)
-
-        XCTAssertEqual(apiClientSpy.lastRequestedPage, 2)
-    }
+    // MARK: - result forwarding
 
     func test_whenGetCharacters_succeeds_shouldReturnResultFromAPIClient() async throws {
         let expectedContainer = CharacterDataContainer.fixture(results: [.fixture(id: 42)])
-        apiClientSpy.result = expectedContainer
+        apiClientSpy.resultProvider = { _ in expectedContainer }
 
         let result = try await sut.getCharacters(page: 1)
 
         XCTAssertEqual(result.results.count, expectedContainer.results.count)
         XCTAssertEqual(result.results.first?.id, expectedContainer.results.first?.id)
     }
+
+    // MARK: - error handling
 
     func test_whenGetCharacters_fails_shouldThrowError() async {
         apiClientSpy.error = TestError.any
@@ -34,21 +36,19 @@ final class CharacterDataSourceTests: XCTestCase {
             _ = try await sut.getCharacters(page: 1)
             XCTFail("Expected error to be thrown")
         } catch {
-            XCTAssertTrue(apiClientSpy.getCharactersCalled)
+            XCTAssertTrue(apiClientSpy.requestCalled)
         }
     }
 
-    func test_whenGetCharacters_withAPIError_shouldMapToAppError() async {
-        let urlError = URLError(.notConnectedToInternet)
-        apiClientSpy.error = urlError
+    func test_whenGetCharacters_withAPIError_shouldMapToNetworkAppError() async {
+        apiClientSpy.error = URLError(.notConnectedToInternet)
 
         do {
             _ = try await sut.getCharacters(page: 1)
             XCTFail("Expected AppError to be thrown")
         } catch let error as AppError {
-            if case .network = error {
-            } else {
-                XCTFail("Expected network error, got \(error)")
+            if case .network = error { } else {
+                XCTFail("Expected .network error, got \(error)")
             }
         } catch {
             XCTFail("Expected AppError, got different error type")

--- a/WallaMarvelTests/Data/GetCharactersRequestTests.swift
+++ b/WallaMarvelTests/Data/GetCharactersRequestTests.swift
@@ -1,0 +1,36 @@
+import XCTest
+@testable import WallaMarvel
+
+final class GetCharactersRequestTests: XCTestCase {
+
+    func test_makeURL_shouldHaveCorrectHostAndPath() throws {
+        let sut = GetCharactersRequest(page: 1)
+        let url = try sut.makeURL()
+
+        XCTAssertEqual(url.host, "rickandmortyapi.com")
+        XCTAssertEqual(url.path, "/api/character")
+    }
+
+    func test_makeURL_shouldUseHTTPS() throws {
+        let sut = GetCharactersRequest(page: 1)
+        let url = try sut.makeURL()
+
+        XCTAssertEqual(url.scheme, "https")
+    }
+
+    func test_makeURL_shouldIncludePageQueryParameter() throws {
+        let sut = GetCharactersRequest(page: 3)
+        let url = try sut.makeURL()
+
+        let components = URLComponents(url: url, resolvingAgainstBaseURL: false)
+        let pageValue = components?.queryItems?.first(where: { $0.name == "page" })?.value
+        XCTAssertEqual(pageValue, "3")
+    }
+
+    func test_makeURL_differentPages_shouldProduceDifferentURLs() throws {
+        let url1 = try GetCharactersRequest(page: 1).makeURL()
+        let url2 = try GetCharactersRequest(page: 2).makeURL()
+
+        XCTAssertNotEqual(url1, url2)
+    }
+}

--- a/WallaMarvelTests/Spies/APIClientSpy.swift
+++ b/WallaMarvelTests/Spies/APIClientSpy.swift
@@ -1,17 +1,16 @@
 @testable import WallaMarvel
 
 final class APIClientSpy: APIClientProtocol {
-    private(set) var getCharactersCalled: Bool = false
-    private(set) var lastRequestedPage: Int = 0
-    var result: CharacterDataContainer = .fixture()
+    private(set) var requestCalled = false
+    private(set) var lastRequest: (any APIRequest)?
+    var resultProvider: ((any APIRequest) throws -> Any)?
     var error: Error?
 
-    func getCharacters(page: Int) async throws -> CharacterDataContainer {
-        getCharactersCalled = true
-        lastRequestedPage = page
-        if let error {
-            throw error
-        }
-        return result
+    func request<T: Decodable>(_ request: any APIRequest) async throws -> T {
+        requestCalled = true
+        lastRequest = request
+        if let error { throw error }
+        if let result = try resultProvider?(request) as? T { return result }
+        throw TestError.any
     }
 }


### PR DESCRIPTION
## Summary

- Refactored `APIClient` to expose a single generic method accepting any `APIRequest`
- Introduced `APIRequest` protocol — each endpoint is responsible for building its own URL
- Created `GetCharactersRequest` struct encapsulating the characters endpoint URL construction
- Introduced `APIEndpoint` enum as single source of truth for base URL and all API paths
- Simplified `CharacterDataSource` — no URL logic, only picks the right request
- Removed force unwrap (`throw lastError!`) in retry loop — replaced with safe `guard let`
- Removed dead code: `String+MD5.swift` (unused MD5 helper, leftover from Marvel API auth)

## Context

- `APIClient` had one method per endpoint — adding new endpoints would keep growing the file
- URL strings were scattered: base URL hardcoded in `CharacterDataSource`, no central registry
- `CharacterDataSource` was building URLs directly, violating Single Responsibility
- A force unwrap existed in the retry loop with no fallback for an empty error state
- `String+MD5.swift` was defined but never called anywhere in the codebase

## Changes

- `APIClient.swift` — protocol and implementation replaced with `func request<T: Decodable>(_ request: any APIRequest) async throws -> T`
- `APIRequest.swift` *(new)* — protocol with single requirement `func makeURL() throws -> URL`
- `GetCharactersRequest.swift` *(new)* — struct encapsulating `/api/character?page=N` URL construction using `APIEndpoint`
- `APIEndpoint.swift` *(new)* — enum with `static let baseURL` and `enum Path: String` (`.characters`, `.episode`)
- `CharacterDataSource.swift` — simplified: delegates URL building to `GetCharactersRequest(page:)`
- `APIClientSpy.swift` — updated to match generic protocol: `lastRequest: (any APIRequest)?`, `resultProvider: ((any APIRequest) throws -> Any)?`
- `String+MD5.swift` *(deleted)* — dead code removed

## Tests

**What was tested:**
- `GetCharactersRequestTests` *(new)*: correct host, HTTPS scheme, `page` query param, different pages produce different URLs
- `APIClientTests`: updated to generic call style via private `TestAPIRequest` stub
- `CharacterDataSourceTests`: removed URL building assertions (responsibility moved to `GetCharactersRequestTests`)

**How it was validated:**
- All existing tests remain green
- `BUILD SUCCEEDED` after every change

## Evidences

- `BUILD SUCCEEDED` ✅
- All test targets passing ✅