### PR TITLE
[WP-03] Implement character details flow with dedicated use case and navigation

### DIFF
--- a/WallaMarvel.xcodeproj/project.pbxproj
+++ b/WallaMarvel.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0032C06B0B130FE8301D5B4B /* EpisodeDataSourceSpy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D17CFACB97F14547FDA15DA /* EpisodeDataSourceSpy.swift */; };
+		07B2C0EEDB0C6721A19AA357 /* EpisodeDataModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0291A77268CD1B64903B8E99 /* EpisodeDataModel.swift */; };
 		0D6A93A4DA0047F880E557F5 /* AppCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81E290EAA75A481AABB9C916 /* AppCoordinatorTests.swift */; };
 		11C665E1A0434754BC325478 /* NavigationCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F50F999FDC134F2FBC1AE674 /* NavigationCoordinatorTests.swift */; };
 		1A0E3A992862F7E200132FCB /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A0E3A982862F7E200132FCB /* AppDelegate.swift */; };
@@ -53,16 +55,29 @@
 		1AE537D32F7E0BE8008BABB4 /* Location+fixture.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AE537D22F7E0BE8008BABB4 /* Location+fixture.swift */; };
 		1AE537D52F7E0BEC008BABB4 /* Thumbnail+fixture.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AE537D42F7E0BEC008BABB4 /* Thumbnail+fixture.swift */; };
 		1AE537D72F7E0BFA008BABB4 /* CharacterDataModel+fixture.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AE537D62F7E0BFA008BABB4 /* CharacterDataModel+fixture.swift */; };
+		2033C4E23FC83062D60CD073 /* EpisodeRepositorySpy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 264FD4D6DE5D2920E3E84F3F /* EpisodeRepositorySpy.swift */; };
+		21289A895CC5252CFD38DB76 /* DetailCharacterPresenterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E43F9A062F2248FADA8DDA39 /* DetailCharacterPresenterTests.swift */; };
+		2CA8495D35D15F366B2105C1 /* EpisodeDataSourceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1E32407DD97A2BEA277717A /* EpisodeDataSourceTests.swift */; };
+		3075D8FF2E219A62B3CD98D9 /* EpisodeDataModel+fixture.swift in Sources */ = {isa = PBXBuildFile; fileRef = D981C70150423FE5166B13BA /* EpisodeDataModel+fixture.swift */; };
 		32E1A29D39CE4052BCCBD93D /* DetailCharacterViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DF9F54FF44D48C59E7A512B /* DetailCharacterViewController.swift */; };
+		47BF94B22A989A3D4450CD3C /* EpisodeDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7922CFBDC86437EB712BE8CA /* EpisodeDataSource.swift */; };
+		4954F4EC1DAFAEE67BBF82FF /* DetailCharacterPresenterSpy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35111E9BA4E4F6CA3DDB01AF /* DetailCharacterPresenterSpy.swift */; };
+		4BF388557A259A748E69C307 /* GetCharacterFirstEpisodeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BB76FE74F67B32AB1BDEF70 /* GetCharacterFirstEpisodeTests.swift */; };
+		4DDA170A0154F85916908EB3 /* GetCharacterFirstEpisodeUseCaseSpy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D5E0AB7BBCADAAE8C231E1C /* GetCharacterFirstEpisodeUseCaseSpy.swift */; };
 		4FDB7E18878F4109925B5550 /* DetailCharacterCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E58D2A6FF494563B81B0AB6 /* DetailCharacterCoordinator.swift */; };
 		5412BD73593E53FEBAD5C932 /* GetCharactersRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21101AD5D5DDC7F54FB4FCB7 /* GetCharactersRequest.swift */; };
+		565172C41918A3AF9B8FFF82 /* DetailCharacterPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FCC4E158F094F3B1B5E7B2F /* DetailCharacterPresenter.swift */; };
 		62A64D24FBF148FC9C96B7B6 /* ListCharactersPresenterSpy.swift in Sources */ = {isa = PBXBuildFile; fileRef = F999718C32A14F03B57291BA /* ListCharactersPresenterSpy.swift */; };
 		6FF50D79AFADE4D4FA3E6F4A /* AppErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D28C8FF45D193ADF868F043 /* AppErrorTests.swift */; };
 		70FE356A1D2E46CF8F23A409 /* AppCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34806026B7C74446890FEAAA /* AppCoordinator.swift */; };
+		81C6CDB86EAFB60DE88A63DC /* GetEpisodeRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = A588A5756D8512EF77380F10 /* GetEpisodeRequest.swift */; };
 		84B2CDB4B18C4BCFB1E2DF7C /* ListCharactersCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 394E89142B384D20ABA450E9 /* ListCharactersCoordinatorTests.swift */; };
+		924A37E6FA38B690FEC354E1 /* Episode+fixture.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E20210EA7D292633BCD6282 /* Episode+fixture.swift */; };
 		9941029E5E8B4E1C841B9595 /* CoordinatorSpy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 361D2986EC92485BBE27626D /* CoordinatorSpy.swift */; };
 		A66389F32DCE202500466318 /* Kingfisher in Frameworks */ = {isa = PBXBuildFile; productRef = A66389F22DCE202500466318 /* Kingfisher */; };
 		AAA33E7B86424403B41EE494 /* NavigationControllerSpy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62812BA212B04EA0A3332DAF /* NavigationControllerSpy.swift */; };
+		B67EF899FA5F01E908A9714F /* EpisodeRepositoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D02A4AF37239390690A1954 /* EpisodeRepositoryTests.swift */; };
+		BB537B58412985674CA3D47D /* Episode.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBD167393AE31AE802C8A636 /* Episode.swift */; };
 		BBB2C3D4E5F6789012345678 /* NavigationCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAB1C2D3E4F567890A1B2C3D /* NavigationCoordinator.swift */; };
 		BCF398D17CBB47258DAB5072 /* DetailCharacterCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DD07A1D63744C428AD00498 /* DetailCharacterCoordinatorTests.swift */; };
 		C0E34B0FEA5F574586DAEE37 /* AppErrorMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 098896F8E8ADBCEA320C7B48 /* AppErrorMapper.swift */; };
@@ -70,7 +85,11 @@
 		C32DE32BD594964F2E9FABEC /* APIRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E6BA011CE2164EC0FC8C895 /* APIRequest.swift */; };
 		C3E25A42127D5A24366898FB /* GetCharactersRequestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8295D9DD7AAF68DE1B56F646 /* GetCharactersRequestTests.swift */; };
 		DC362878A9F819C902162AD5 /* APIEndpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2444602288BBE8E4976DC45 /* APIEndpoint.swift */; };
+		E08619E11DA7DE77605DDF16 /* EpisodeDataModel+Mapping.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DF7AC183022367CC5901E04 /* EpisodeDataModel+Mapping.swift */; };
+		E983D7431F5D023D771FB1A8 /* EpisodeRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A8026D70B99D566B4C16C59 /* EpisodeRepository.swift */; };
 		ECEE354E22C34945A90688BC /* Coordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFDCAA3E5318472B9C43F70A /* Coordinator.swift */; };
+		F12F2ED11F2D5C2AB737CCF1 /* DetailCharacterUISpy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A49215F749761CDC5E45ECA /* DetailCharacterUISpy.swift */; };
+		F213DBAC10064F4D892EAED5 /* GetCharacterFirstEpisode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42C02881D77CA9FF0470A8DC /* GetCharacterFirstEpisode.swift */; };
 		F585F2C321223DDD15051939 /* AppError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DCD5856E0C7CEDDA14C48D5 /* AppError.swift */; };
 		F8958390974A92B22B51A0CE /* AppErrorMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7331CFD7344EAA013BAF60E8 /* AppErrorMapperTests.swift */; };
 /* End PBXBuildFile section */
@@ -93,6 +112,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		0291A77268CD1B64903B8E99 /* EpisodeDataModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = EpisodeDataModel.swift; sourceTree = "<group>"; };
 		098896F8E8ADBCEA320C7B48 /* AppErrorMapper.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AppErrorMapper.swift; path = WallaMarvel/Data/ErrorMapping/AppErrorMapper.swift; sourceTree = "<group>"; };
 		1A0E3A952862F7E200132FCB /* WallaMarvel.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = WallaMarvel.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		1A0E3A982862F7E200132FCB /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -110,6 +130,7 @@
 		1A3B7327286ADEE6007BF626 /* ListCharactersTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListCharactersTableViewCell.swift; sourceTree = "<group>"; };
 		1A3B7329286AE195007BF626 /* ListCharactersAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListCharactersAdapter.swift; sourceTree = "<group>"; };
 		1A7B9BBE286D81B600EBC1A6 /* Thumbnail.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Thumbnail.swift; sourceTree = "<group>"; };
+		1A8026D70B99D566B4C16C59 /* EpisodeRepository.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = EpisodeRepository.swift; sourceTree = "<group>"; };
 		1A821EC82862FE3C0024D397 /* APIClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIClient.swift; sourceTree = "<group>"; };
 		1A821ED3286302EC0024D397 /* CharacterResponseDataModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CharacterResponseDataModel.swift; sourceTree = "<group>"; };
 		1A821ED5286305590024D397 /* CharacterDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CharacterDataSource.swift; sourceTree = "<group>"; };
@@ -142,24 +163,41 @@
 		1AE537D22F7E0BE8008BABB4 /* Location+fixture.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Location+fixture.swift"; sourceTree = "<group>"; };
 		1AE537D42F7E0BEC008BABB4 /* Thumbnail+fixture.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Thumbnail+fixture.swift"; sourceTree = "<group>"; };
 		1AE537D62F7E0BFA008BABB4 /* CharacterDataModel+fixture.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CharacterDataModel+fixture.swift"; sourceTree = "<group>"; };
+		1D17CFACB97F14547FDA15DA /* EpisodeDataSourceSpy.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = EpisodeDataSourceSpy.swift; sourceTree = "<group>"; };
 		1DCD5856E0C7CEDDA14C48D5 /* AppError.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AppError.swift; path = WallaMarvel/Domain/Errors/AppError.swift; sourceTree = "<group>"; };
 		1DD07A1D63744C428AD00498 /* DetailCharacterCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailCharacterCoordinatorTests.swift; sourceTree = "<group>"; };
 		1E6BA011CE2164EC0FC8C895 /* APIRequest.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = APIRequest.swift; path = Requests/APIRequest.swift; sourceTree = "<group>"; };
 		21101AD5D5DDC7F54FB4FCB7 /* GetCharactersRequest.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = GetCharactersRequest.swift; path = Requests/GetCharactersRequest.swift; sourceTree = "<group>"; };
+		264FD4D6DE5D2920E3E84F3F /* EpisodeRepositorySpy.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = EpisodeRepositorySpy.swift; sourceTree = "<group>"; };
+		2A49215F749761CDC5E45ECA /* DetailCharacterUISpy.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DetailCharacterUISpy.swift; sourceTree = "<group>"; };
+		2DF7AC183022367CC5901E04 /* EpisodeDataModel+Mapping.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "EpisodeDataModel+Mapping.swift"; sourceTree = "<group>"; };
 		34806026B7C74446890FEAAA /* AppCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppCoordinator.swift; sourceTree = "<group>"; };
+		35111E9BA4E4F6CA3DDB01AF /* DetailCharacterPresenterSpy.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DetailCharacterPresenterSpy.swift; sourceTree = "<group>"; };
 		361D2986EC92485BBE27626D /* CoordinatorSpy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoordinatorSpy.swift; sourceTree = "<group>"; };
 		394E89142B384D20ABA450E9 /* ListCharactersCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListCharactersCoordinatorTests.swift; sourceTree = "<group>"; };
+		3D02A4AF37239390690A1954 /* EpisodeRepositoryTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = EpisodeRepositoryTests.swift; sourceTree = "<group>"; };
 		3DF9F54FF44D48C59E7A512B /* DetailCharacterViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailCharacterViewController.swift; sourceTree = "<group>"; };
+		3E20210EA7D292633BCD6282 /* Episode+fixture.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "Episode+fixture.swift"; sourceTree = "<group>"; };
+		42C02881D77CA9FF0470A8DC /* GetCharacterFirstEpisode.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GetCharacterFirstEpisode.swift; sourceTree = "<group>"; };
+		4D5E0AB7BBCADAAE8C231E1C /* GetCharacterFirstEpisodeUseCaseSpy.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GetCharacterFirstEpisodeUseCaseSpy.swift; sourceTree = "<group>"; };
 		5E58D2A6FF494563B81B0AB6 /* DetailCharacterCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailCharacterCoordinator.swift; sourceTree = "<group>"; };
 		62812BA212B04EA0A3332DAF /* NavigationControllerSpy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationControllerSpy.swift; sourceTree = "<group>"; };
 		7331CFD7344EAA013BAF60E8 /* AppErrorMapperTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AppErrorMapperTests.swift; sourceTree = "<group>"; };
+		7922CFBDC86437EB712BE8CA /* EpisodeDataSource.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = EpisodeDataSource.swift; sourceTree = "<group>"; };
+		7BB76FE74F67B32AB1BDEF70 /* GetCharacterFirstEpisodeTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GetCharacterFirstEpisodeTests.swift; sourceTree = "<group>"; };
 		81E290EAA75A481AABB9C916 /* AppCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppCoordinatorTests.swift; sourceTree = "<group>"; };
 		8295D9DD7AAF68DE1B56F646 /* GetCharactersRequestTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GetCharactersRequestTests.swift; sourceTree = "<group>"; };
 		9B8FD56AF9DD44179F23488E /* ListCharactersCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListCharactersCoordinator.swift; sourceTree = "<group>"; };
 		9D28C8FF45D193ADF868F043 /* AppErrorTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AppErrorTests.swift; sourceTree = "<group>"; };
+		9FCC4E158F094F3B1B5E7B2F /* DetailCharacterPresenter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DetailCharacterPresenter.swift; sourceTree = "<group>"; };
 		A2444602288BBE8E4976DC45 /* APIEndpoint.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = APIEndpoint.swift; path = Requests/APIEndpoint.swift; sourceTree = "<group>"; };
+		A588A5756D8512EF77380F10 /* GetEpisodeRequest.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = GetEpisodeRequest.swift; path = Requests/GetEpisodeRequest.swift; sourceTree = "<group>"; };
 		AAB1C2D3E4F567890A1B2C3D /* NavigationCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationCoordinator.swift; sourceTree = "<group>"; };
+		B1E32407DD97A2BEA277717A /* EpisodeDataSourceTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = EpisodeDataSourceTests.swift; sourceTree = "<group>"; };
+		BBD167393AE31AE802C8A636 /* Episode.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Episode.swift; sourceTree = "<group>"; };
 		CFDCAA3E5318472B9C43F70A /* Coordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Coordinator.swift; sourceTree = "<group>"; };
+		D981C70150423FE5166B13BA /* EpisodeDataModel+fixture.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "EpisodeDataModel+fixture.swift"; sourceTree = "<group>"; };
+		E43F9A062F2248FADA8DDA39 /* DetailCharacterPresenterTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DetailCharacterPresenterTests.swift; sourceTree = "<group>"; };
 		F50F999FDC134F2FBC1AE674 /* NavigationCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationCoordinatorTests.swift; sourceTree = "<group>"; };
 		F999718C32A14F03B57291BA /* ListCharactersPresenterSpy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListCharactersPresenterSpy.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -267,6 +305,7 @@
 			isa = PBXGroup;
 			children = (
 				3DF9F54FF44D48C59E7A512B /* DetailCharacterViewController.swift */,
+				9FCC4E158F094F3B1B5E7B2F /* DetailCharacterPresenter.swift */,
 			);
 			path = DetailCharacter;
 			sourceTree = "<group>";
@@ -277,6 +316,7 @@
 				1A821ED72863081A0024D397 /* CharacterRepository.swift */,
 				1AC0347D286320F000E93178 /* UseCases */,
 				1AA67B972F7E1EA4002C7F2E /* Entities */,
+				1A8026D70B99D566B4C16C59 /* EpisodeRepository.swift */,
 			);
 			path = Domain;
 			sourceTree = "<group>";
@@ -290,6 +330,7 @@
 				1A821ECA2862FF910024D397 /* Helpers */,
 				1AA67B9A2F7E1EA8002C7F2E /* Mapping */,
 				97DF30D59FE87B76C0592E10 /* Requests */,
+				7922CFBDC86437EB712BE8CA /* EpisodeDataSource.swift */,
 			);
 			path = Data;
 			sourceTree = "<group>";
@@ -310,6 +351,7 @@
 				1AE537BB2F7E0459008BABB4 /* PageInfo.swift */,
 				1A821ED3286302EC0024D397 /* CharacterResponseDataModel.swift */,
 				1A7B9BBE286D81B600EBC1A6 /* Thumbnail.swift */,
+				0291A77268CD1B64903B8E99 /* EpisodeDataModel.swift */,
 			);
 			path = DataModel;
 			sourceTree = "<group>";
@@ -329,6 +371,7 @@
 				1AA67B842F7E1400002C7F2E /* UseCases */,
 				1AA67B952F7E152C002C7F2E /* CharacterRepositoryTests.swift */,
 				9D28C8FF45D193ADF868F043 /* AppErrorTests.swift */,
+				3D02A4AF37239390690A1954 /* EpisodeRepositoryTests.swift */,
 			);
 			path = Domain;
 			sourceTree = "<group>";
@@ -337,6 +380,7 @@
 			isa = PBXGroup;
 			children = (
 				1AA67B852F7E1407002C7F2E /* GetCharactersTests.swift */,
+				7BB76FE74F67B32AB1BDEF70 /* GetCharacterFirstEpisodeTests.swift */,
 			);
 			path = UseCases;
 			sourceTree = "<group>";
@@ -358,6 +402,7 @@
 				1AA67B932F7E1525002C7F2E /* CharacterDataSourceTests.swift */,
 				7331CFD7344EAA013BAF60E8 /* AppErrorMapperTests.swift */,
 				8295D9DD7AAF68DE1B56F646 /* GetCharactersRequestTests.swift */,
+				B1E32407DD97A2BEA277717A /* EpisodeDataSourceTests.swift */,
 			);
 			path = Data;
 			sourceTree = "<group>";
@@ -366,6 +411,7 @@
 			isa = PBXGroup;
 			children = (
 				1AA67B982F7E1EA6002C7F2E /* Character.swift */,
+				BBD167393AE31AE802C8A636 /* Episode.swift */,
 			);
 			path = Entities;
 			sourceTree = "<group>";
@@ -374,6 +420,7 @@
 			isa = PBXGroup;
 			children = (
 				1AA67B9B2F7E1EAB002C7F2E /* CharacterDataModel+Mapping.swift */,
+				2DF7AC183022367CC5901E04 /* EpisodeDataModel+Mapping.swift */,
 			);
 			path = Mapping;
 			sourceTree = "<group>";
@@ -382,6 +429,7 @@
 			isa = PBXGroup;
 			children = (
 				1AC0347E2863214900E93178 /* GetCharacters.swift */,
+				42C02881D77CA9FF0470A8DC /* GetCharacterFirstEpisode.swift */,
 			);
 			path = UseCases;
 			sourceTree = "<group>";
@@ -394,6 +442,7 @@
 				81E290EAA75A481AABB9C916 /* AppCoordinatorTests.swift */,
 				394E89142B384D20ABA450E9 /* ListCharactersCoordinatorTests.swift */,
 				1DD07A1D63744C428AD00498 /* DetailCharacterCoordinatorTests.swift */,
+				E43F9A062F2248FADA8DDA39 /* DetailCharacterPresenterTests.swift */,
 			);
 			path = Presentation;
 			sourceTree = "<group>";
@@ -409,6 +458,11 @@
 				361D2986EC92485BBE27626D /* CoordinatorSpy.swift */,
 				62812BA212B04EA0A3332DAF /* NavigationControllerSpy.swift */,
 				F999718C32A14F03B57291BA /* ListCharactersPresenterSpy.swift */,
+				1D17CFACB97F14547FDA15DA /* EpisodeDataSourceSpy.swift */,
+				264FD4D6DE5D2920E3E84F3F /* EpisodeRepositorySpy.swift */,
+				4D5E0AB7BBCADAAE8C231E1C /* GetCharacterFirstEpisodeUseCaseSpy.swift */,
+				35111E9BA4E4F6CA3DDB01AF /* DetailCharacterPresenterSpy.swift */,
+				2A49215F749761CDC5E45ECA /* DetailCharacterUISpy.swift */,
 			);
 			path = Spies;
 			sourceTree = "<group>";
@@ -423,6 +477,8 @@
 				1AE537D42F7E0BEC008BABB4 /* Thumbnail+fixture.swift */,
 				1AE537D62F7E0BFA008BABB4 /* CharacterDataModel+fixture.swift */,
 				1AA67B9D2F7E1EDA002C7F2E /* Character+fixture.swift */,
+				3E20210EA7D292633BCD6282 /* Episode+fixture.swift */,
+				D981C70150423FE5166B13BA /* EpisodeDataModel+fixture.swift */,
 			);
 			path = Fixtures;
 			sourceTree = "<group>";
@@ -457,6 +513,7 @@
 				1E6BA011CE2164EC0FC8C895 /* APIRequest.swift */,
 				21101AD5D5DDC7F54FB4FCB7 /* GetCharactersRequest.swift */,
 				A2444602288BBE8E4976DC45 /* APIEndpoint.swift */,
+				A588A5756D8512EF77380F10 /* GetEpisodeRequest.swift */,
 			);
 			name = Requests;
 			sourceTree = "<group>";
@@ -644,6 +701,14 @@
 				C32DE32BD594964F2E9FABEC /* APIRequest.swift in Sources */,
 				5412BD73593E53FEBAD5C932 /* GetCharactersRequest.swift in Sources */,
 				DC362878A9F819C902162AD5 /* APIEndpoint.swift in Sources */,
+				BB537B58412985674CA3D47D /* Episode.swift in Sources */,
+				E983D7431F5D023D771FB1A8 /* EpisodeRepository.swift in Sources */,
+				F213DBAC10064F4D892EAED5 /* GetCharacterFirstEpisode.swift in Sources */,
+				07B2C0EEDB0C6721A19AA357 /* EpisodeDataModel.swift in Sources */,
+				E08619E11DA7DE77605DDF16 /* EpisodeDataModel+Mapping.swift in Sources */,
+				47BF94B22A989A3D4450CD3C /* EpisodeDataSource.swift in Sources */,
+				81C6CDB86EAFB60DE88A63DC /* GetEpisodeRequest.swift in Sources */,
+				565172C41918A3AF9B8FFF82 /* DetailCharacterPresenter.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -682,6 +747,17 @@
 				84B2CDB4B18C4BCFB1E2DF7C /* ListCharactersCoordinatorTests.swift in Sources */,
 				BCF398D17CBB47258DAB5072 /* DetailCharacterCoordinatorTests.swift in Sources */,
 				C3E25A42127D5A24366898FB /* GetCharactersRequestTests.swift in Sources */,
+				924A37E6FA38B690FEC354E1 /* Episode+fixture.swift in Sources */,
+				3075D8FF2E219A62B3CD98D9 /* EpisodeDataModel+fixture.swift in Sources */,
+				0032C06B0B130FE8301D5B4B /* EpisodeDataSourceSpy.swift in Sources */,
+				2033C4E23FC83062D60CD073 /* EpisodeRepositorySpy.swift in Sources */,
+				4DDA170A0154F85916908EB3 /* GetCharacterFirstEpisodeUseCaseSpy.swift in Sources */,
+				4954F4EC1DAFAEE67BBF82FF /* DetailCharacterPresenterSpy.swift in Sources */,
+				F12F2ED11F2D5C2AB737CCF1 /* DetailCharacterUISpy.swift in Sources */,
+				2CA8495D35D15F366B2105C1 /* EpisodeDataSourceTests.swift in Sources */,
+				B67EF899FA5F01E908A9714F /* EpisodeRepositoryTests.swift in Sources */,
+				4BF388557A259A748E69C307 /* GetCharacterFirstEpisodeTests.swift in Sources */,
+				21289A895CC5252CFD38DB76 /* DetailCharacterPresenterTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/WallaMarvel/Data/CharacterDataSource.swift
+++ b/WallaMarvel/Data/CharacterDataSource.swift
@@ -7,7 +7,7 @@ protocol CharacterDataSourceProtocol {
 final class CharacterDataSource: CharacterDataSourceProtocol {
     private let apiClient: APIClientProtocol
     
-    init(apiClient: APIClientProtocol = APIClient()) {
+    init(apiClient: APIClientProtocol) {
         self.apiClient = apiClient
     }
     

--- a/WallaMarvel/Data/DataModel/EpisodeDataModel.swift
+++ b/WallaMarvel/Data/DataModel/EpisodeDataModel.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+struct EpisodeDataModel: Decodable {
+    let id: Int
+    let name: String
+    let airDate: String
+    let episode: String
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case name
+        case airDate = "air_date"
+        case episode
+    }
+}

--- a/WallaMarvel/Data/EpisodeDataSource.swift
+++ b/WallaMarvel/Data/EpisodeDataSource.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+protocol EpisodeDataSourceProtocol {
+    func getEpisode(url: String) async throws -> EpisodeDataModel
+}
+
+final class EpisodeDataSource: EpisodeDataSourceProtocol {
+    private let apiClient: APIClientProtocol
+
+    init(apiClient: APIClientProtocol = APIClient()) {
+        self.apiClient = apiClient
+    }
+
+    func getEpisode(url: String) async throws -> EpisodeDataModel {
+        do {
+            return try await apiClient.request(GetEpisodeRequest(urlString: url))
+        } catch {
+            throw AppErrorMapper.map(error)
+        }
+    }
+}

--- a/WallaMarvel/Data/EpisodeDataSource.swift
+++ b/WallaMarvel/Data/EpisodeDataSource.swift
@@ -7,7 +7,7 @@ protocol EpisodeDataSourceProtocol {
 final class EpisodeDataSource: EpisodeDataSourceProtocol {
     private let apiClient: APIClientProtocol
 
-    init(apiClient: APIClientProtocol = APIClient()) {
+    init(apiClient: APIClientProtocol) {
         self.apiClient = apiClient
     }
 

--- a/WallaMarvel/Data/Mapping/CharacterDataModel+Mapping.swift
+++ b/WallaMarvel/Data/Mapping/CharacterDataModel+Mapping.swift
@@ -7,11 +7,13 @@ extension CharacterDataModel {
             name: name,
             status: status,
             species: species,
+            type: type,
             gender: gender,
             imageURL: image,
             originName: origin.name,
             locationName: location.name,
-            episodeCount: episode.count
+            episodeCount: episode.count,
+            firstEpisodeURL: episode.first
         )
     }
 }

--- a/WallaMarvel/Data/Mapping/EpisodeDataModel+Mapping.swift
+++ b/WallaMarvel/Data/Mapping/EpisodeDataModel+Mapping.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+extension EpisodeDataModel {
+    func toDomain() -> Episode {
+        Episode(id: id, name: name, airDate: airDate, code: episode)
+    }
+}

--- a/WallaMarvel/Data/Requests/GetEpisodeRequest.swift
+++ b/WallaMarvel/Data/Requests/GetEpisodeRequest.swift
@@ -1,0 +1,12 @@
+import Foundation
+
+struct GetEpisodeRequest: APIRequest {
+    let urlString: String
+
+    func makeURL() throws -> URL {
+        guard let url = URL(string: urlString) else {
+            throw AppError.invalidData("Invalid episode URL: \(urlString)")
+        }
+        return url
+    }
+}

--- a/WallaMarvel/Domain/CharacterRepository.swift
+++ b/WallaMarvel/Domain/CharacterRepository.swift
@@ -7,7 +7,7 @@ protocol CharacterRepositoryProtocol {
 final class CharacterRepository: CharacterRepositoryProtocol {
     private let dataSource: CharacterDataSourceProtocol
     
-    init(dataSource: CharacterDataSourceProtocol = CharacterDataSource()) {
+    init(dataSource: CharacterDataSourceProtocol) {
         self.dataSource = dataSource
     }
     

--- a/WallaMarvel/Domain/Entities/Character.swift
+++ b/WallaMarvel/Domain/Entities/Character.swift
@@ -9,22 +9,26 @@ struct Character: Equatable {
     let name: String
     let status: String
     let species: String
+    let type: String
     let gender: String
     let imageURL: String
     let originName: String
     let locationName: String
     let episodeCount: Int
-    
+    let firstEpisodeURL: String?
+
     init(
         id: Int,
         name: String,
         status: String,
         species: String,
+        type: String,
         gender: String,
         imageURL: String,
         originName: String,
         locationName: String,
-        episodeCount: Int
+        episodeCount: Int,
+        firstEpisodeURL: String? = nil
     ) throws {
         guard !imageURL.isEmpty,
               let url = URL(string: imageURL),
@@ -36,11 +40,13 @@ struct Character: Equatable {
         self.name = name
         self.status = status
         self.species = species
+        self.type = type
         self.gender = gender
         self.imageURL = imageURL
         self.originName = originName
         self.locationName = locationName
         self.episodeCount = episodeCount
+        self.firstEpisodeURL = firstEpisodeURL
     }
 }
 

--- a/WallaMarvel/Domain/Entities/Episode.swift
+++ b/WallaMarvel/Domain/Entities/Episode.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+struct Episode: Equatable {
+    let id: Int
+    let name: String
+    let airDate: String
+    let code: String
+}

--- a/WallaMarvel/Domain/EpisodeRepository.swift
+++ b/WallaMarvel/Domain/EpisodeRepository.swift
@@ -1,0 +1,24 @@
+import Foundation
+
+protocol EpisodeRepositoryProtocol {
+    func getEpisode(url: String) async throws -> Episode
+}
+
+final class EpisodeRepository: EpisodeRepositoryProtocol {
+    private let dataSource: EpisodeDataSourceProtocol
+
+    init(dataSource: EpisodeDataSourceProtocol = EpisodeDataSource()) {
+        self.dataSource = dataSource
+    }
+
+    func getEpisode(url: String) async throws -> Episode {
+        do {
+            let dataModel = try await dataSource.getEpisode(url: url)
+            return dataModel.toDomain()
+        } catch let error as AppError {
+            throw error
+        } catch {
+            throw AppErrorMapper.map(error)
+        }
+    }
+}

--- a/WallaMarvel/Domain/EpisodeRepository.swift
+++ b/WallaMarvel/Domain/EpisodeRepository.swift
@@ -7,7 +7,7 @@ protocol EpisodeRepositoryProtocol {
 final class EpisodeRepository: EpisodeRepositoryProtocol {
     private let dataSource: EpisodeDataSourceProtocol
 
-    init(dataSource: EpisodeDataSourceProtocol = EpisodeDataSource()) {
+    init(dataSource: EpisodeDataSourceProtocol) {
         self.dataSource = dataSource
     }
 

--- a/WallaMarvel/Domain/UseCases/GetCharacterFirstEpisode.swift
+++ b/WallaMarvel/Domain/UseCases/GetCharacterFirstEpisode.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+protocol GetCharacterFirstEpisodeUseCaseProtocol {
+    func execute(episodeURL: String) async throws -> Episode
+}
+
+struct GetCharacterFirstEpisode: GetCharacterFirstEpisodeUseCaseProtocol {
+    private let repository: EpisodeRepositoryProtocol
+
+    init(repository: EpisodeRepositoryProtocol = EpisodeRepository()) {
+        self.repository = repository
+    }
+
+    func execute(episodeURL: String) async throws -> Episode {
+        try await repository.getEpisode(url: episodeURL)
+    }
+}

--- a/WallaMarvel/Domain/UseCases/GetCharacterFirstEpisode.swift
+++ b/WallaMarvel/Domain/UseCases/GetCharacterFirstEpisode.swift
@@ -7,7 +7,7 @@ protocol GetCharacterFirstEpisodeUseCaseProtocol {
 struct GetCharacterFirstEpisode: GetCharacterFirstEpisodeUseCaseProtocol {
     private let repository: EpisodeRepositoryProtocol
 
-    init(repository: EpisodeRepositoryProtocol = EpisodeRepository()) {
+    init(repository: EpisodeRepositoryProtocol) {
         self.repository = repository
     }
 

--- a/WallaMarvel/Domain/UseCases/GetCharacters.swift
+++ b/WallaMarvel/Domain/UseCases/GetCharacters.swift
@@ -7,7 +7,7 @@ protocol GetCharactersUseCaseProtocol {
 struct GetCharacters: GetCharactersUseCaseProtocol {
     private let repository: CharacterRepositoryProtocol
     
-    init(repository: CharacterRepositoryProtocol = CharacterRepository()) {
+    init(repository: CharacterRepositoryProtocol) {
         self.repository = repository
     }
     

--- a/WallaMarvel/Presentation/Coordinators/ListCharactersCoordinator.swift
+++ b/WallaMarvel/Presentation/Coordinators/ListCharactersCoordinator.swift
@@ -32,7 +32,9 @@ final class ListCharactersCoordinator: NavigationCoordinator {
 extension ListCharactersCoordinator: ListCharactersCoordinatorProtocol {
     @MainActor
     func showDetail(for character: Character) {
-        let detailViewController = DetailCharacterViewController(character: character)
+        let presenter = DetailCharacterPresenter(character: character)
+        let detailViewController = DetailCharacterViewController(character: character, presenter: presenter)
+        presenter.ui = detailViewController
         let coordinator = DetailCharacterCoordinator(
             navigationController: navigationController,
             viewController: detailViewController

--- a/WallaMarvel/Presentation/Coordinators/ListCharactersCoordinator.swift
+++ b/WallaMarvel/Presentation/Coordinators/ListCharactersCoordinator.swift
@@ -32,7 +32,11 @@ final class ListCharactersCoordinator: NavigationCoordinator {
 extension ListCharactersCoordinator: ListCharactersCoordinatorProtocol {
     @MainActor
     func showDetail(for character: Character) {
-        let presenter = DetailCharacterPresenter(character: character)
+        let apiClient = APIClient()
+        let episodeDataSource = EpisodeDataSource(apiClient: apiClient)
+        let episodeRepository = EpisodeRepository(dataSource: episodeDataSource)
+        let getFirstEpisodeUseCase = GetCharacterFirstEpisode(repository: episodeRepository)
+        let presenter = DetailCharacterPresenter(character: character, getFirstEpisodeUseCase: getFirstEpisodeUseCase)
         let detailViewController = DetailCharacterViewController(character: character, presenter: presenter)
         presenter.ui = detailViewController
         let coordinator = DetailCharacterCoordinator(

--- a/WallaMarvel/Presentation/ListCharacter/DetailCharacter/DetailCharacterPresenter.swift
+++ b/WallaMarvel/Presentation/ListCharacter/DetailCharacter/DetailCharacterPresenter.swift
@@ -1,0 +1,48 @@
+import Foundation
+
+@MainActor
+protocol DetailCharacterPresenterProtocol: AnyObject {
+    var ui: DetailCharacterUI? { get set }
+    func loadEpisode() async
+}
+
+@MainActor
+protocol DetailCharacterUI: AnyObject {
+    func showEpisodeLoading()
+    func showEpisode(_ episode: Episode)
+    func showEpisodeError(_ error: AppError)
+}
+
+@MainActor
+final class DetailCharacterPresenter: DetailCharacterPresenterProtocol {
+    var ui: DetailCharacterUI?
+    private let character: Character
+    private let getFirstEpisodeUseCase: GetCharacterFirstEpisodeUseCaseProtocol
+    private var isLoadingEpisode = false
+
+    init(
+        character: Character,
+        getFirstEpisodeUseCase: GetCharacterFirstEpisodeUseCaseProtocol = GetCharacterFirstEpisode()
+    ) {
+        self.character = character
+        self.getFirstEpisodeUseCase = getFirstEpisodeUseCase
+    }
+
+    func loadEpisode() async {
+        guard let episodeURL = character.firstEpisodeURL else { return }
+        guard !isLoadingEpisode else { return }
+        isLoadingEpisode = true
+        ui?.showEpisodeLoading()
+        do {
+            let episode = try await getFirstEpisodeUseCase.execute(episodeURL: episodeURL)
+            isLoadingEpisode = false
+            ui?.showEpisode(episode)
+        } catch let error as AppError {
+            isLoadingEpisode = false
+            ui?.showEpisodeError(error)
+        } catch {
+            isLoadingEpisode = false
+            ui?.showEpisodeError(AppErrorMapper.map(error))
+        }
+    }
+}

--- a/WallaMarvel/Presentation/ListCharacter/DetailCharacter/DetailCharacterPresenter.swift
+++ b/WallaMarvel/Presentation/ListCharacter/DetailCharacter/DetailCharacterPresenter.swift
@@ -22,7 +22,7 @@ final class DetailCharacterPresenter: DetailCharacterPresenterProtocol {
 
     init(
         character: Character,
-        getFirstEpisodeUseCase: GetCharacterFirstEpisodeUseCaseProtocol = GetCharacterFirstEpisode()
+        getFirstEpisodeUseCase: GetCharacterFirstEpisodeUseCaseProtocol
     ) {
         self.character = character
         self.getFirstEpisodeUseCase = getFirstEpisodeUseCase

--- a/WallaMarvel/Presentation/ListCharacter/DetailCharacter/DetailCharacterViewController.swift
+++ b/WallaMarvel/Presentation/ListCharacter/DetailCharacter/DetailCharacterViewController.swift
@@ -1,10 +1,85 @@
 import UIKit
+import Kingfisher
 
 final class DetailCharacterViewController: UIViewController {
     private let character: Character
+    var presenter: DetailCharacterPresenterProtocol?
 
-    init(character: Character) {
+    // MARK: - UI
+
+    private let scrollView = UIScrollView()
+    private let contentStack: UIStackView = {
+        let stack = UIStackView()
+        stack.axis = .vertical
+        stack.spacing = 16
+        stack.layoutMargins = UIEdgeInsets(top: 24, left: 16, bottom: 24, right: 16)
+        stack.isLayoutMarginsRelativeArrangement = true
+        return stack
+    }()
+
+    private let imageView: UIImageView = {
+        let iv = UIImageView()
+        iv.contentMode = .scaleAspectFill
+        iv.clipsToBounds = true
+        iv.layer.cornerRadius = 100
+        iv.translatesAutoresizingMaskIntoConstraints = false
+        return iv
+    }()
+
+    private let statusBadge: UILabel = {
+        let label = UILabel()
+        label.font = .systemFont(ofSize: 14, weight: .semibold)
+        label.textColor = .white
+        label.layer.cornerRadius = 10
+        label.layer.masksToBounds = true
+        label.textAlignment = .center
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+
+    private let episodeSectionLabel: UILabel = {
+        let label = UILabel()
+        label.text = "First seen in"
+        label.font = .systemFont(ofSize: 17, weight: .semibold)
+        return label
+    }()
+
+    private let episodeLoadingIndicator: UIActivityIndicatorView = {
+        let indicator = UIActivityIndicatorView(style: .medium)
+        indicator.hidesWhenStopped = true
+        return indicator
+    }()
+
+    private let episodeInfoLabel: UILabel = {
+        let label = UILabel()
+        label.numberOfLines = 0
+        label.font = .systemFont(ofSize: 15)
+        label.isHidden = true
+        return label
+    }()
+
+    private let episodeErrorLabel: UILabel = {
+        let label = UILabel()
+        label.numberOfLines = 0
+        label.font = .systemFont(ofSize: 15)
+        label.textColor = .systemRed
+        label.isHidden = true
+        return label
+    }()
+
+    private lazy var retryButton: UIButton = {
+        let button = UIButton(type: .system)
+        button.setTitle("Retry", for: .normal)
+        button.addTarget(self, action: #selector(retryTapped), for: .touchUpInside)
+        button.isHidden = true
+        return button
+    }()
+
+    // MARK: - Init
+
+    init(character: Character, presenter: DetailCharacterPresenterProtocol? = nil) {
         self.character = character
+        self.presenter = presenter
         super.init(nibName: nil, bundle: nil)
     }
 
@@ -12,9 +87,159 @@ final class DetailCharacterViewController: UIViewController {
         fatalError("init(coder:) has not been implemented")
     }
 
+    // MARK: - Lifecycle
+
     override func viewDidLoad() {
         super.viewDidLoad()
         view.backgroundColor = .systemBackground
         title = character.name
+        setupLayout()
+        populate()
+        Task { await presenter?.loadEpisode() }
+    }
+
+    // MARK: - Setup
+
+    private func setupLayout() {
+        scrollView.translatesAutoresizingMaskIntoConstraints = false
+        contentStack.translatesAutoresizingMaskIntoConstraints = false
+
+        view.addSubview(scrollView)
+        scrollView.addSubview(contentStack)
+
+        NSLayoutConstraint.activate([
+            scrollView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+            scrollView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            scrollView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            scrollView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+
+            contentStack.topAnchor.constraint(equalTo: scrollView.topAnchor),
+            contentStack.leadingAnchor.constraint(equalTo: scrollView.leadingAnchor),
+            contentStack.trailingAnchor.constraint(equalTo: scrollView.trailingAnchor),
+            contentStack.bottomAnchor.constraint(equalTo: scrollView.bottomAnchor),
+            contentStack.widthAnchor.constraint(equalTo: scrollView.widthAnchor)
+        ])
+    }
+
+    private func populate() {
+        addImageView()
+        addStatusBadge()
+        addInfoRows()
+        addEpisodeSection()
+    }
+
+    private func addImageView() {
+        let container = UIView()
+        container.addSubview(imageView)
+        NSLayoutConstraint.activate([
+            imageView.centerXAnchor.constraint(equalTo: container.centerXAnchor),
+            imageView.topAnchor.constraint(equalTo: container.topAnchor),
+            imageView.bottomAnchor.constraint(equalTo: container.bottomAnchor),
+            imageView.widthAnchor.constraint(equalToConstant: 200),
+            imageView.heightAnchor.constraint(equalToConstant: 200)
+        ])
+        contentStack.addArrangedSubview(container)
+
+        if let url = URL(string: character.imageURL) {
+            imageView.kf.setImage(with: url, options: [.transition(.fade(0.2)), .cacheOriginalImage])
+        }
+    }
+
+    private func addStatusBadge() {
+        let status = character.status.lowercased()
+        let (text, color): (String, UIColor) = {
+            switch status {
+            case "alive": return ("● Alive", .systemGreen)
+            case "dead":  return ("● Dead", .systemRed)
+            default:      return ("● Unknown", .systemGray)
+            }
+        }()
+        statusBadge.text = "  \(text)  "
+        statusBadge.backgroundColor = color
+
+        let container = UIView()
+        container.addSubview(statusBadge)
+        NSLayoutConstraint.activate([
+            statusBadge.centerXAnchor.constraint(equalTo: container.centerXAnchor),
+            statusBadge.topAnchor.constraint(equalTo: container.topAnchor),
+            statusBadge.bottomAnchor.constraint(equalTo: container.bottomAnchor),
+            statusBadge.heightAnchor.constraint(equalToConstant: 28)
+        ])
+        contentStack.addArrangedSubview(container)
+    }
+
+    private func addInfoRows() {
+        contentStack.addArrangedSubview(makeInfoRow(title: "Species", value: character.species))
+        if !character.type.isEmpty {
+            contentStack.addArrangedSubview(makeInfoRow(title: "Type", value: character.type))
+        }
+        contentStack.addArrangedSubview(makeInfoRow(title: "Gender", value: character.gender))
+        contentStack.addArrangedSubview(makeInfoRow(title: "Origin", value: character.originName))
+        contentStack.addArrangedSubview(makeInfoRow(title: "Location", value: character.locationName))
+        contentStack.addArrangedSubview(makeInfoRow(title: "Episodes", value: "\(character.episodeCount)"))
+    }
+
+    private func addEpisodeSection() {
+        contentStack.addArrangedSubview(episodeSectionLabel)
+        contentStack.addArrangedSubview(episodeLoadingIndicator)
+        contentStack.addArrangedSubview(episodeInfoLabel)
+        contentStack.addArrangedSubview(episodeErrorLabel)
+        contentStack.addArrangedSubview(retryButton)
+    }
+
+    private func makeInfoRow(title: String, value: String) -> UIView {
+        let row = UIStackView()
+        row.axis = .horizontal
+        row.spacing = 8
+        row.distribution = .equalSpacing
+
+        let titleLabel = UILabel()
+        titleLabel.text = title
+        titleLabel.font = .systemFont(ofSize: 15, weight: .semibold)
+        titleLabel.setContentHuggingPriority(.defaultHigh, for: .horizontal)
+
+        let valueLabel = UILabel()
+        valueLabel.text = value
+        valueLabel.font = .systemFont(ofSize: 15)
+        valueLabel.textAlignment = .right
+        valueLabel.numberOfLines = 0
+
+        row.addArrangedSubview(titleLabel)
+        row.addArrangedSubview(valueLabel)
+        return row
+    }
+
+    // MARK: - Actions
+
+    @objc private func retryTapped() {
+        Task { await presenter?.loadEpisode() }
     }
 }
+
+// MARK: - DetailCharacterUI
+
+extension DetailCharacterViewController: DetailCharacterUI {
+    func showEpisodeLoading() {
+        episodeLoadingIndicator.startAnimating()
+        episodeInfoLabel.isHidden = true
+        episodeErrorLabel.isHidden = true
+        retryButton.isHidden = true
+    }
+
+    func showEpisode(_ episode: Episode) {
+        episodeLoadingIndicator.stopAnimating()
+        episodeInfoLabel.text = "\(episode.name) (\(episode.code))\n\(episode.airDate)"
+        episodeInfoLabel.isHidden = false
+        episodeErrorLabel.isHidden = true
+        retryButton.isHidden = true
+    }
+
+    func showEpisodeError(_ error: AppError) {
+        episodeLoadingIndicator.stopAnimating()
+        episodeErrorLabel.text = error.userMessage
+        episodeErrorLabel.isHidden = false
+        episodeInfoLabel.isHidden = true
+        retryButton.isHidden = false
+    }
+}
+

--- a/WallaMarvel/Presentation/ListCharacter/ListCharactersPresenter.swift
+++ b/WallaMarvel/Presentation/ListCharacter/ListCharactersPresenter.swift
@@ -31,7 +31,7 @@ final class ListCharactersPresenter: ListCharactersPresenterProtocol {
     private var isLoadingPage = false
     private var isPaginationBlocked = false
 
-    init(getCharactersUseCase: GetCharactersUseCaseProtocol = GetCharacters()) {
+    init(getCharactersUseCase: GetCharactersUseCaseProtocol) {
         self.getCharactersUseCase = getCharactersUseCase
     }
 

--- a/WallaMarvel/SceneDelegate.swift
+++ b/WallaMarvel/SceneDelegate.swift
@@ -13,7 +13,11 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         self.window = window
 
         let navigationController = UINavigationController()
-        let presenter = ListCharactersPresenter()
+        let apiClient = APIClient()
+        let characterDataSource = CharacterDataSource(apiClient: apiClient)
+        let characterRepository = CharacterRepository(dataSource: characterDataSource)
+        let getCharactersUseCase = GetCharacters(repository: characterRepository)
+        let presenter = ListCharactersPresenter(getCharactersUseCase: getCharactersUseCase)
         let listViewController = ListCharactersViewController()
         let listCoordinator = ListCharactersCoordinator(
             navigationController: navigationController,

--- a/WallaMarvelTests/Data/EpisodeDataSourceTests.swift
+++ b/WallaMarvelTests/Data/EpisodeDataSourceTests.swift
@@ -1,0 +1,72 @@
+import XCTest
+@testable import WallaMarvel
+
+final class EpisodeDataSourceTests: XCTestCase {
+    private let apiClientSpy = APIClientSpy()
+    private lazy var sut = EpisodeDataSource(apiClient: apiClientSpy)
+
+    // MARK: - request delegation
+
+    func test_whenGetEpisode_called_shouldCallAPIClient() async throws {
+        apiClientSpy.resultProvider = { _ in EpisodeDataModel.fixture() }
+
+        _ = try await sut.getEpisode(url: "https://rickandmortyapi.com/api/episode/1")
+
+        XCTAssertTrue(apiClientSpy.requestCalled)
+    }
+
+    // MARK: - URL passthrough
+
+    func test_whenGetEpisode_called_shouldPassCorrectURL() async throws {
+        let episodeURL = "https://rickandmortyapi.com/api/episode/1"
+        apiClientSpy.resultProvider = { _ in EpisodeDataModel.fixture() }
+
+        _ = try await sut.getEpisode(url: episodeURL)
+
+        let requestedURL = try XCTUnwrap(apiClientSpy.lastRequest?.makeURL())
+        XCTAssertEqual(requestedURL.absoluteString, episodeURL)
+    }
+
+    // MARK: - result forwarding
+
+    func test_whenGetEpisode_succeeds_shouldReturnResultFromAPIClient() async throws {
+        let expected = EpisodeDataModel.fixture(id: 1, name: "Pilot")
+        apiClientSpy.resultProvider = { _ in expected }
+
+        let result = try await sut.getEpisode(url: "https://rickandmortyapi.com/api/episode/1")
+
+        XCTAssertEqual(result.id, expected.id)
+        XCTAssertEqual(result.name, expected.name)
+    }
+
+    // MARK: - error handling
+
+    func test_whenGetEpisode_withURLError_shouldMapToNetworkAppError() async {
+        apiClientSpy.error = URLError(.notConnectedToInternet)
+
+        do {
+            _ = try await sut.getEpisode(url: "https://rickandmortyapi.com/api/episode/1")
+            XCTFail("Expected error to be thrown")
+        } catch let error as AppError {
+            if case .network = error { } else {
+                XCTFail("Expected .network error, got \(error)")
+            }
+        } catch {
+            XCTFail("Expected AppError")
+        }
+    }
+
+    func test_whenGetEpisode_withAppError_shouldRethrow() async {
+        let appError = AppError.decoding("Decoding failed")
+        apiClientSpy.error = appError
+
+        do {
+            _ = try await sut.getEpisode(url: "https://rickandmortyapi.com/api/episode/1")
+            XCTFail("Expected error to be thrown")
+        } catch let error as AppError {
+            XCTAssertEqual(error, appError)
+        } catch {
+            XCTFail("Expected AppError")
+        }
+    }
+}

--- a/WallaMarvelTests/Domain/EpisodeRepositoryTests.swift
+++ b/WallaMarvelTests/Domain/EpisodeRepositoryTests.swift
@@ -1,0 +1,67 @@
+import XCTest
+@testable import WallaMarvel
+
+final class EpisodeRepositoryTests: XCTestCase {
+    private let dataSourceSpy = EpisodeDataSourceSpy()
+    private lazy var sut = EpisodeRepository(dataSource: dataSourceSpy)
+
+    // MARK: - request delegation
+
+    func test_whenGetEpisode_called_shouldCallDataSource() async throws {
+        _ = try await sut.getEpisode(url: "https://example.com/episode/1")
+
+        XCTAssertTrue(dataSourceSpy.getEpisodeCalled)
+    }
+
+    func test_whenGetEpisode_called_shouldPassURLToDataSource() async throws {
+        let url = "https://example.com/episode/1"
+        _ = try await sut.getEpisode(url: url)
+
+        XCTAssertEqual(dataSourceSpy.lastRequestedURL, url)
+    }
+
+    // MARK: - domain mapping
+
+    func test_whenGetEpisode_succeeds_shouldMapToDomain() async throws {
+        let dataModel = EpisodeDataModel.fixture(id: 42, name: "Pilot", airDate: "December 2, 2013", episode: "S01E01")
+        dataSourceSpy.result = dataModel
+
+        let result = try await sut.getEpisode(url: "https://example.com/episode/1")
+
+        XCTAssertEqual(result.id, 42)
+        XCTAssertEqual(result.name, "Pilot")
+        XCTAssertEqual(result.airDate, "December 2, 2013")
+        XCTAssertEqual(result.code, "S01E01")
+    }
+
+    // MARK: - error handling
+
+    func test_whenGetEpisode_withAppError_shouldRethrow() async {
+        let appError = AppError.network("Connection failed")
+        dataSourceSpy.error = appError
+
+        do {
+            _ = try await sut.getEpisode(url: "https://example.com/episode/1")
+            XCTFail("Expected error to be thrown")
+        } catch let error as AppError {
+            XCTAssertEqual(error, appError)
+        } catch {
+            XCTFail("Expected AppError")
+        }
+    }
+
+    func test_whenGetEpisode_withUnknownError_shouldMapToUnknownAppError() async {
+        dataSourceSpy.error = TestError.any
+
+        do {
+            _ = try await sut.getEpisode(url: "https://example.com/episode/1")
+            XCTFail("Expected error to be thrown")
+        } catch let error as AppError {
+            if case .unknown = error { } else {
+                XCTFail("Expected .unknown error, got \(error)")
+            }
+        } catch {
+            XCTFail("Expected AppError")
+        }
+    }
+}

--- a/WallaMarvelTests/Domain/UseCases/GetCharacterFirstEpisodeTests.swift
+++ b/WallaMarvelTests/Domain/UseCases/GetCharacterFirstEpisodeTests.swift
@@ -1,0 +1,50 @@
+import XCTest
+@testable import WallaMarvel
+
+final class GetCharacterFirstEpisodeTests: XCTestCase {
+    private let repositorySpy = EpisodeRepositorySpy()
+    private lazy var sut = GetCharacterFirstEpisode(repository: repositorySpy)
+
+    // MARK: - request delegation
+
+    func test_whenExecute_called_shouldCallRepository() async throws {
+        _ = try await sut.execute(episodeURL: "https://example.com/episode/1")
+
+        XCTAssertTrue(repositorySpy.getEpisodeCalled)
+    }
+
+    func test_whenExecute_called_shouldPassURLToRepository() async throws {
+        let url = "https://example.com/episode/1"
+        _ = try await sut.execute(episodeURL: url)
+
+        XCTAssertEqual(repositorySpy.lastRequestedURL, url)
+    }
+
+    // MARK: - result forwarding
+
+    func test_whenExecute_succeeds_shouldReturnEpisode() async throws {
+        let expected = Episode.fixture(id: 42, name: "Rickmancing the Stone")
+        repositorySpy.result = expected
+
+        let result = try await sut.execute(episodeURL: "https://example.com/episode/42")
+
+        XCTAssertEqual(result.id, expected.id)
+        XCTAssertEqual(result.name, expected.name)
+    }
+
+    // MARK: - error propagation
+
+    func test_whenExecute_fails_shouldPropagateError() async {
+        let appError = AppError.network("No connection")
+        repositorySpy.error = appError
+
+        do {
+            _ = try await sut.execute(episodeURL: "https://example.com/episode/1")
+            XCTFail("Expected error to be thrown")
+        } catch let error as AppError {
+            XCTAssertEqual(error, appError)
+        } catch {
+            XCTFail("Expected AppError")
+        }
+    }
+}

--- a/WallaMarvelTests/Fixtures/Character+fixture.swift
+++ b/WallaMarvelTests/Fixtures/Character+fixture.swift
@@ -6,22 +6,26 @@ extension Character {
         name: String = "Rick Sanchez",
         status: String = "Alive",
         species: String = "Human",
+        type: String = "",
         gender: String = "Male",
         imageURL: String = "https://example.com/character/1.png",
         originName: String = "Earth",
         locationName: String = "Earth",
-        episodeCount: Int = 10
+        episodeCount: Int = 10,
+        firstEpisodeURL: String? = "https://rickandmortyapi.com/api/episode/1"
     ) -> Self {
         try! Character(
             id: id,
             name: name,
             status: status,
             species: species,
+            type: type,
             gender: gender,
             imageURL: imageURL,
             originName: originName,
             locationName: locationName,
-            episodeCount: episodeCount
+            episodeCount: episodeCount,
+            firstEpisodeURL: firstEpisodeURL
         )
     }
 }

--- a/WallaMarvelTests/Fixtures/Episode+fixture.swift
+++ b/WallaMarvelTests/Fixtures/Episode+fixture.swift
@@ -1,0 +1,12 @@
+@testable import WallaMarvel
+
+extension Episode {
+    static func fixture(
+        id: Int = 1,
+        name: String = "Pilot",
+        airDate: String = "December 2, 2013",
+        code: String = "S01E01"
+    ) -> Self {
+        Episode(id: id, name: name, airDate: airDate, code: code)
+    }
+}

--- a/WallaMarvelTests/Fixtures/EpisodeDataModel+fixture.swift
+++ b/WallaMarvelTests/Fixtures/EpisodeDataModel+fixture.swift
@@ -1,0 +1,12 @@
+@testable import WallaMarvel
+
+extension EpisodeDataModel {
+    static func fixture(
+        id: Int = 1,
+        name: String = "Pilot",
+        airDate: String = "December 2, 2013",
+        episode: String = "S01E01"
+    ) -> Self {
+        EpisodeDataModel(id: id, name: name, airDate: airDate, episode: episode)
+    }
+}

--- a/WallaMarvelTests/Presentation/DetailCharacterPresenterTests.swift
+++ b/WallaMarvelTests/Presentation/DetailCharacterPresenterTests.swift
@@ -1,0 +1,83 @@
+import XCTest
+@testable import WallaMarvel
+
+@MainActor
+final class DetailCharacterPresenterTests: XCTestCase {
+    private let useCaseSpy = GetCharacterFirstEpisodeUseCaseSpy()
+    private let uiSpy = DetailCharacterUISpy()
+
+    private func makeSUT(
+        firstEpisodeURL: String? = "https://rickandmortyapi.com/api/episode/1"
+    ) -> DetailCharacterPresenter {
+        let character = Character.fixture(firstEpisodeURL: firstEpisodeURL)
+        let sut = DetailCharacterPresenter(character: character, getFirstEpisodeUseCase: useCaseSpy)
+        sut.ui = uiSpy
+        return sut
+    }
+
+    // MARK: - use case delegation
+
+    func test_whenLoadEpisode_called_shouldCallUseCase() async {
+        let sut = makeSUT()
+        await sut.loadEpisode()
+
+        XCTAssertTrue(useCaseSpy.executeCalled)
+    }
+
+    func test_whenLoadEpisode_withNilEpisodeURL_shouldNotCallUseCase() async {
+        let sut = makeSUT(firstEpisodeURL: nil)
+        await sut.loadEpisode()
+
+        XCTAssertFalse(useCaseSpy.executeCalled)
+    }
+
+    func test_whenLoadEpisode_called_shouldPassCorrectURL() async {
+        let episodeURL = "https://rickandmortyapi.com/api/episode/1"
+        let sut = makeSUT(firstEpisodeURL: episodeURL)
+        await sut.loadEpisode()
+
+        XCTAssertEqual(useCaseSpy.lastRequestedURL, episodeURL)
+    }
+
+    // MARK: - loading state
+
+    func test_whenLoadEpisode_called_shouldShowLoading() async {
+        let sut = makeSUT()
+        await sut.loadEpisode()
+
+        XCTAssertTrue(uiSpy.showEpisodeLoadingCalled)
+    }
+
+    // MARK: - success
+
+    func test_whenLoadEpisode_succeeds_shouldShowEpisode() async {
+        let expected = Episode.fixture()
+        useCaseSpy.result = expected
+        let sut = makeSUT()
+        await sut.loadEpisode()
+
+        XCTAssertEqual(uiSpy.shownEpisode?.id, expected.id)
+        XCTAssertEqual(uiSpy.shownEpisode?.name, expected.name)
+    }
+
+    // MARK: - error handling
+
+    func test_whenLoadEpisode_withAppError_shouldShowError() async {
+        let appError = AppError.network("No connection")
+        useCaseSpy.error = appError
+        let sut = makeSUT()
+        await sut.loadEpisode()
+
+        XCTAssertEqual(uiSpy.shownError, appError)
+    }
+
+    func test_whenLoadEpisode_withUnknownError_shouldMapAndShowError() async {
+        useCaseSpy.error = TestError.any
+        let sut = makeSUT()
+        await sut.loadEpisode()
+
+        if case .unknown = uiSpy.shownError { } else {
+            XCTFail("Expected .unknown error, got \(String(describing: uiSpy.shownError))")
+        }
+    }
+}

--- a/WallaMarvelTests/Spies/DetailCharacterPresenterSpy.swift
+++ b/WallaMarvelTests/Spies/DetailCharacterPresenterSpy.swift
@@ -1,0 +1,11 @@
+@testable import WallaMarvel
+
+@MainActor
+final class DetailCharacterPresenterSpy: DetailCharacterPresenterProtocol {
+    var ui: DetailCharacterUI?
+    private(set) var loadEpisodeCalled = false
+
+    func loadEpisode() async {
+        loadEpisodeCalled = true
+    }
+}

--- a/WallaMarvelTests/Spies/DetailCharacterUISpy.swift
+++ b/WallaMarvelTests/Spies/DetailCharacterUISpy.swift
@@ -1,0 +1,19 @@
+@testable import WallaMarvel
+
+final class DetailCharacterUISpy: DetailCharacterUI {
+    private(set) var showEpisodeLoadingCalled = false
+    private(set) var shownEpisode: Episode?
+    private(set) var shownError: AppError?
+
+    func showEpisodeLoading() {
+        showEpisodeLoadingCalled = true
+    }
+
+    func showEpisode(_ episode: Episode) {
+        shownEpisode = episode
+    }
+
+    func showEpisodeError(_ error: AppError) {
+        shownError = error
+    }
+}

--- a/WallaMarvelTests/Spies/EpisodeDataSourceSpy.swift
+++ b/WallaMarvelTests/Spies/EpisodeDataSourceSpy.swift
@@ -1,0 +1,15 @@
+@testable import WallaMarvel
+
+final class EpisodeDataSourceSpy: EpisodeDataSourceProtocol {
+    private(set) var getEpisodeCalled = false
+    private(set) var lastRequestedURL: String?
+    var result: EpisodeDataModel = .fixture()
+    var error: Error?
+
+    func getEpisode(url: String) async throws -> EpisodeDataModel {
+        getEpisodeCalled = true
+        lastRequestedURL = url
+        if let error { throw error }
+        return result
+    }
+}

--- a/WallaMarvelTests/Spies/EpisodeRepositorySpy.swift
+++ b/WallaMarvelTests/Spies/EpisodeRepositorySpy.swift
@@ -1,0 +1,15 @@
+@testable import WallaMarvel
+
+final class EpisodeRepositorySpy: EpisodeRepositoryProtocol {
+    private(set) var getEpisodeCalled = false
+    private(set) var lastRequestedURL: String?
+    var result: Episode = .fixture()
+    var error: Error?
+
+    func getEpisode(url: String) async throws -> Episode {
+        getEpisodeCalled = true
+        lastRequestedURL = url
+        if let error { throw error }
+        return result
+    }
+}

--- a/WallaMarvelTests/Spies/GetCharacterFirstEpisodeUseCaseSpy.swift
+++ b/WallaMarvelTests/Spies/GetCharacterFirstEpisodeUseCaseSpy.swift
@@ -1,0 +1,15 @@
+@testable import WallaMarvel
+
+final class GetCharacterFirstEpisodeUseCaseSpy: GetCharacterFirstEpisodeUseCaseProtocol {
+    private(set) var executeCalled = false
+    private(set) var lastRequestedURL: String?
+    var result: Episode = .fixture()
+    var error: Error?
+
+    func execute(episodeURL: String) async throws -> Episode {
+        executeCalled = true
+        lastRequestedURL = episodeURL
+        if let error { throw error }
+        return result
+    }
+}


### PR DESCRIPTION
## Summary

- Implemented the character detail screen with full Clean Architecture flow
- Added `Episode` entity, `EpisodeRepository`, and `GetCharacterFirstEpisode` use case
- Extended `Character` entity with `type` and `firstEpisodeURL` fields
- Added `EpisodeDataModel`, `EpisodeDataSource`, and `GetEpisodeRequest` following the existing `APIRequest` pattern
- Implemented `DetailCharacterPresenter` with `DetailCharacterUI` protocol — static character data always visible, episode section with 3 states: loading, success, error + retry
- Implemented `DetailCharacterViewController`: scroll view, circular image with Kingfisher cache, status badge, info rows, episode section
- Removed default parameters from all `init`s — composition root moved exclusively to `SceneDelegate` and `ListCharactersCoordinator`

## Context

- `DetailCharacterViewController` existed as a stub — no layout, no presenter, no episode section
- `Character` entity lacked `type` and `firstEpisodeURL` fields, which were already present in `CharacterDataModel`
- All `init`s across DataSources, Repositories, and UseCases had default concrete dependencies, violating DIP — each type knew its own concrete dependency
- `ListCharactersPresenter` and `DetailCharacterPresenter` also had auto-injected defaults, hiding the dependency graph

## Evidence
![details](https://github.com/user-attachments/assets/9bd382e3-b731-454a-9d22-5c274f65b915)

## Changes

- `Episode.swift` *(new)* — `id`, `name`, `airDate`, `code`
- `EpisodeRepository.swift` *(new)* — protocol + implementation
- `GetCharacterFirstEpisode.swift` *(new)* — use case
- `Character.swift` — added `type: String` and `firstEpisodeURL: String?`
- `EpisodeDataModel.swift` *(new)* — Decodable with `air_date → airDate` via CodingKeys
- `EpisodeDataModel+Mapping.swift` *(new)* — `toDomain()`
- `EpisodeDataSource.swift` *(new)* — protocol + implementation using `GetEpisodeRequest`
- `GetEpisodeRequest.swift` *(new)* — `APIRequest` struct for episode endpoint
- `CharacterDataModel+Mapping.swift` — maps `type` and `firstEpisodeURL: episode.first`
- `DetailCharacterPresenter.swift` *(new)* — `DetailCharacterPresenterProtocol` + `DetailCharacterUI` + implementation
- `DetailCharacterViewController.swift` — full implementation replacing stub
- `ListCharactersCoordinator.swift` — builds explicit dependency graph for detail screen in `showDetail(for:)`
- `SceneDelegate.swift` — explicit dependency graph for list screen
- All `init`s across DataSources, Repositories, UseCases, and Presenters — default parameters removed

## Tests

What was tested:

- `EpisodeDataSourceTests` *(new)*: `APIClient` called, URL passthrough, result forwarding, `URLError → .network`, `AppError` rethrow
- `EpisodeRepositoryTests` *(new)*: DataSource called, URL passthrough, `toDomain()` mapping, `AppError` rethrow, unknown error → `.unknown`
- `GetCharacterFirstEpisodeTests` *(new)*: repository called, URL passthrough, result forwarding, error propagation
- `DetailCharacterPresenterTests` *(new)*: use case called, no-op when `firstEpisodeURL == nil`, correct URL passed, loading shown, episode shown on success, `AppError` shown, unknown error mapped to `.unknown`

How it was validated:

- All existing tests remain green
- `BUILD SUCCEEDED` after every change