### PR TITLE
[WP-12] Code improvement move magic numbers to a constant

### DIFF
--- a/WallaMarvel/Presentation/ListCharacter/DetailCharacter/DetailCharacterViewController.swift
+++ b/WallaMarvel/Presentation/ListCharacter/DetailCharacter/DetailCharacterViewController.swift
@@ -2,6 +2,38 @@ import UIKit
 import Kingfisher
 
 final class DetailCharacterViewController: UIViewController {
+
+    // MARK: - Constants
+
+    private enum Constants {
+        static let stackSpacing: CGFloat = 16
+        static let contentInset: CGFloat = 16
+        static let contentVerticalInset: CGFloat = 24
+        static let imageSize: CGFloat = 200
+        static let imageCornerRadius: CGFloat = 100
+        static let badgeFontSize: CGFloat = 14
+        static let badgeCornerRadius: CGFloat = 10
+        static let badgeHeight: CGFloat = 28
+        static let sectionFontSize: CGFloat = 17
+        static let rowFontSize: CGFloat = 15
+        static let rowSpacing: CGFloat = 8
+        static let imageFadeDuration: CGFloat = 0.2
+    }
+
+    private enum Strings {
+        static let firstSeenIn = "First seen in"
+        static let retry = "Retry"
+        static let statusAlive = "● Alive"
+        static let statusDead = "● Dead"
+        static let statusUnknown = "● Unknown"
+        static let rowSpecies = "Species"
+        static let rowType = "Type"
+        static let rowGender = "Gender"
+        static let rowOrigin = "Origin"
+        static let rowLocation = "Location"
+        static let rowEpisodes = "Episodes"
+    }
+
     private let character: Character
     var presenter: DetailCharacterPresenterProtocol?
 
@@ -11,8 +43,13 @@ final class DetailCharacterViewController: UIViewController {
     private let contentStack: UIStackView = {
         let stack = UIStackView()
         stack.axis = .vertical
-        stack.spacing = 16
-        stack.layoutMargins = UIEdgeInsets(top: 24, left: 16, bottom: 24, right: 16)
+        stack.spacing = Constants.stackSpacing
+        stack.layoutMargins = UIEdgeInsets(
+            top: Constants.contentVerticalInset,
+            left: Constants.contentInset,
+            bottom: Constants.contentVerticalInset,
+            right: Constants.contentInset
+        )
         stack.isLayoutMarginsRelativeArrangement = true
         return stack
     }()
@@ -21,16 +58,16 @@ final class DetailCharacterViewController: UIViewController {
         let iv = UIImageView()
         iv.contentMode = .scaleAspectFill
         iv.clipsToBounds = true
-        iv.layer.cornerRadius = 100
+        iv.layer.cornerRadius = Constants.imageCornerRadius
         iv.translatesAutoresizingMaskIntoConstraints = false
         return iv
     }()
 
     private let statusBadge: UILabel = {
         let label = UILabel()
-        label.font = .systemFont(ofSize: 14, weight: .semibold)
+        label.font = .systemFont(ofSize: Constants.badgeFontSize, weight: .semibold)
         label.textColor = .white
-        label.layer.cornerRadius = 10
+        label.layer.cornerRadius = Constants.badgeCornerRadius
         label.layer.masksToBounds = true
         label.textAlignment = .center
         label.translatesAutoresizingMaskIntoConstraints = false
@@ -39,8 +76,8 @@ final class DetailCharacterViewController: UIViewController {
 
     private let episodeSectionLabel: UILabel = {
         let label = UILabel()
-        label.text = "First seen in"
-        label.font = .systemFont(ofSize: 17, weight: .semibold)
+        label.text = Strings.firstSeenIn
+        label.font = .systemFont(ofSize: Constants.sectionFontSize, weight: .semibold)
         return label
     }()
 
@@ -53,7 +90,7 @@ final class DetailCharacterViewController: UIViewController {
     private let episodeInfoLabel: UILabel = {
         let label = UILabel()
         label.numberOfLines = 0
-        label.font = .systemFont(ofSize: 15)
+        label.font = .systemFont(ofSize: Constants.rowFontSize)
         label.isHidden = true
         return label
     }()
@@ -61,7 +98,7 @@ final class DetailCharacterViewController: UIViewController {
     private let episodeErrorLabel: UILabel = {
         let label = UILabel()
         label.numberOfLines = 0
-        label.font = .systemFont(ofSize: 15)
+        label.font = .systemFont(ofSize: Constants.rowFontSize)
         label.textColor = .systemRed
         label.isHidden = true
         return label
@@ -69,7 +106,7 @@ final class DetailCharacterViewController: UIViewController {
 
     private lazy var retryButton: UIButton = {
         let button = UIButton(type: .system)
-        button.setTitle("Retry", for: .normal)
+        button.setTitle(Strings.retry, for: .normal)
         button.addTarget(self, action: #selector(retryTapped), for: .touchUpInside)
         button.isHidden = true
         return button
@@ -135,13 +172,13 @@ final class DetailCharacterViewController: UIViewController {
             imageView.centerXAnchor.constraint(equalTo: container.centerXAnchor),
             imageView.topAnchor.constraint(equalTo: container.topAnchor),
             imageView.bottomAnchor.constraint(equalTo: container.bottomAnchor),
-            imageView.widthAnchor.constraint(equalToConstant: 200),
-            imageView.heightAnchor.constraint(equalToConstant: 200)
+            imageView.widthAnchor.constraint(equalToConstant: Constants.imageSize),
+            imageView.heightAnchor.constraint(equalToConstant: Constants.imageSize)
         ])
         contentStack.addArrangedSubview(container)
 
         if let url = URL(string: character.imageURL) {
-            imageView.kf.setImage(with: url, options: [.transition(.fade(0.2)), .cacheOriginalImage])
+            imageView.kf.setImage(with: url, options: [.transition(.fade(Constants.imageFadeDuration)), .cacheOriginalImage])
         }
     }
 
@@ -149,9 +186,9 @@ final class DetailCharacterViewController: UIViewController {
         let status = character.status.lowercased()
         let (text, color): (String, UIColor) = {
             switch status {
-            case "alive": return ("● Alive", .systemGreen)
-            case "dead":  return ("● Dead", .systemRed)
-            default:      return ("● Unknown", .systemGray)
+            case "alive": return (Strings.statusAlive, .systemGreen)
+            case "dead":  return (Strings.statusDead, .systemRed)
+            default:      return (Strings.statusUnknown, .systemGray)
             }
         }()
         statusBadge.text = "  \(text)  "
@@ -163,20 +200,20 @@ final class DetailCharacterViewController: UIViewController {
             statusBadge.centerXAnchor.constraint(equalTo: container.centerXAnchor),
             statusBadge.topAnchor.constraint(equalTo: container.topAnchor),
             statusBadge.bottomAnchor.constraint(equalTo: container.bottomAnchor),
-            statusBadge.heightAnchor.constraint(equalToConstant: 28)
+            statusBadge.heightAnchor.constraint(equalToConstant: Constants.badgeHeight)
         ])
         contentStack.addArrangedSubview(container)
     }
 
     private func addInfoRows() {
-        contentStack.addArrangedSubview(makeInfoRow(title: "Species", value: character.species))
+        contentStack.addArrangedSubview(makeInfoRow(title: Strings.rowSpecies, value: character.species))
         if !character.type.isEmpty {
-            contentStack.addArrangedSubview(makeInfoRow(title: "Type", value: character.type))
+            contentStack.addArrangedSubview(makeInfoRow(title: Strings.rowType, value: character.type))
         }
-        contentStack.addArrangedSubview(makeInfoRow(title: "Gender", value: character.gender))
-        contentStack.addArrangedSubview(makeInfoRow(title: "Origin", value: character.originName))
-        contentStack.addArrangedSubview(makeInfoRow(title: "Location", value: character.locationName))
-        contentStack.addArrangedSubview(makeInfoRow(title: "Episodes", value: "\(character.episodeCount)"))
+        contentStack.addArrangedSubview(makeInfoRow(title: Strings.rowGender, value: character.gender))
+        contentStack.addArrangedSubview(makeInfoRow(title: Strings.rowOrigin, value: character.originName))
+        contentStack.addArrangedSubview(makeInfoRow(title: Strings.rowLocation, value: character.locationName))
+        contentStack.addArrangedSubview(makeInfoRow(title: Strings.rowEpisodes, value: "\(character.episodeCount)"))
     }
 
     private func addEpisodeSection() {
@@ -190,17 +227,17 @@ final class DetailCharacterViewController: UIViewController {
     private func makeInfoRow(title: String, value: String) -> UIView {
         let row = UIStackView()
         row.axis = .horizontal
-        row.spacing = 8
+        row.spacing = Constants.rowSpacing
         row.distribution = .equalSpacing
 
         let titleLabel = UILabel()
         titleLabel.text = title
-        titleLabel.font = .systemFont(ofSize: 15, weight: .semibold)
+        titleLabel.font = .systemFont(ofSize: Constants.rowFontSize, weight: .semibold)
         titleLabel.setContentHuggingPriority(.defaultHigh, for: .horizontal)
 
         let valueLabel = UILabel()
         valueLabel.text = value
-        valueLabel.font = .systemFont(ofSize: 15)
+        valueLabel.font = .systemFont(ofSize: Constants.rowFontSize)
         valueLabel.textAlignment = .right
         valueLabel.numberOfLines = 0
 

--- a/WallaMarvel/Presentation/ListCharacter/ListCharactersPresenter.swift
+++ b/WallaMarvel/Presentation/ListCharacter/ListCharactersPresenter.swift
@@ -23,6 +23,10 @@ protocol ListCharactersUI: AnyObject {
 
 @MainActor
 final class ListCharactersPresenter: ListCharactersPresenterProtocol {
+    private enum Strings {
+        static let screenTitle = "List of Characters"
+    }
+
     var ui: ListCharactersUI?
     private let getCharactersUseCase: GetCharactersUseCaseProtocol
 
@@ -36,7 +40,7 @@ final class ListCharactersPresenter: ListCharactersPresenterProtocol {
     }
 
     func screenTitle() -> String {
-        "List of Characters"
+        Strings.screenTitle
     }
 
     func getCharacters() async {

--- a/WallaMarvel/Presentation/ListCharacter/ListCharactersTableView.swift
+++ b/WallaMarvel/Presentation/ListCharacter/ListCharactersTableView.swift
@@ -2,8 +2,19 @@ import Foundation
 import UIKit
 
 final class ListCharactersView: UIView {
-    enum Constant {
+    private enum Constants {
         static let estimatedRowHeight: CGFloat = 120
+        static let errorLabelHorizontalInset: CGFloat = 24
+        static let errorLabelVerticalOffset: CGFloat = -40
+        static let retryButtonTopSpacing: CGFloat = 24
+        static let retryButtonWidth: CGFloat = 120
+        static let retryButtonHeight: CGFloat = 44
+        static let retryButtonCornerRadius: CGFloat = 8
+        static let fontSize: CGFloat = 16
+    }
+
+    private enum Strings {
+        static let retry = "Retry"
     }
     
     private let charactersTableView: UITableView = {
@@ -11,7 +22,7 @@ final class ListCharactersView: UIView {
         tableView.register(ListCharactersTableViewCell.self, forCellReuseIdentifier: "ListCharactersTableViewCell")
         tableView.translatesAutoresizingMaskIntoConstraints = false
         tableView.rowHeight = UITableView.automaticDimension
-        tableView.estimatedRowHeight = Constant.estimatedRowHeight
+        tableView.estimatedRowHeight = Constants.estimatedRowHeight
         return tableView
     }()
     
@@ -42,7 +53,7 @@ final class ListCharactersView: UIView {
         label.translatesAutoresizingMaskIntoConstraints = false
         label.numberOfLines = 0
         label.textAlignment = .center
-        label.font = UIFont.systemFont(ofSize: 16, weight: .regular)
+        label.font = UIFont.systemFont(ofSize: Constants.fontSize, weight: .regular)
         label.textColor = .darkText
         return label
     }()
@@ -50,11 +61,11 @@ final class ListCharactersView: UIView {
     private let retryButton: UIButton = {
         let button = UIButton(type: .system)
         button.translatesAutoresizingMaskIntoConstraints = false
-        button.setTitle("Retry", for: .normal)
-        button.titleLabel?.font = UIFont.systemFont(ofSize: 16, weight: .semibold)
+        button.setTitle(Strings.retry, for: .normal)
+        button.titleLabel?.font = UIFont.systemFont(ofSize: Constants.fontSize, weight: .semibold)
         button.backgroundColor = .systemBlue
         button.setTitleColor(.white, for: .normal)
-        button.layer.cornerRadius = 8
+        button.layer.cornerRadius = Constants.retryButtonCornerRadius
         return button
     }()
     
@@ -102,14 +113,14 @@ final class ListCharactersView: UIView {
             errorContainerView.topAnchor.constraint(equalTo: topAnchor),
             errorContainerView.bottomAnchor.constraint(equalTo: bottomAnchor),
             
-            errorLabel.leadingAnchor.constraint(equalTo: errorContainerView.leadingAnchor, constant: 24),
-            errorLabel.trailingAnchor.constraint(equalTo: errorContainerView.trailingAnchor, constant: -24),
-            errorLabel.centerYAnchor.constraint(equalTo: errorContainerView.centerYAnchor, constant: -40),
+            errorLabel.leadingAnchor.constraint(equalTo: errorContainerView.leadingAnchor, constant: Constants.errorLabelHorizontalInset),
+            errorLabel.trailingAnchor.constraint(equalTo: errorContainerView.trailingAnchor, constant: -Constants.errorLabelHorizontalInset),
+            errorLabel.centerYAnchor.constraint(equalTo: errorContainerView.centerYAnchor, constant: Constants.errorLabelVerticalOffset),
             
-            retryButton.topAnchor.constraint(equalTo: errorLabel.bottomAnchor, constant: 24),
+            retryButton.topAnchor.constraint(equalTo: errorLabel.bottomAnchor, constant: Constants.retryButtonTopSpacing),
             retryButton.centerXAnchor.constraint(equalTo: errorContainerView.centerXAnchor),
-            retryButton.widthAnchor.constraint(equalToConstant: 120),
-            retryButton.heightAnchor.constraint(equalToConstant: 44),
+            retryButton.widthAnchor.constraint(equalToConstant: Constants.retryButtonWidth),
+            retryButton.heightAnchor.constraint(equalToConstant: Constants.retryButtonHeight),
         ])
     }
 

--- a/WallaMarvel/Presentation/ListCharacter/ListCharactersTableViewCell.swift
+++ b/WallaMarvel/Presentation/ListCharacter/ListCharactersTableViewCell.swift
@@ -3,6 +3,11 @@ import UIKit
 import Kingfisher
 
 final class ListCharactersTableViewCell: UITableViewCell {
+    private enum Constants {
+        static let imageSize: CGFloat = 80
+        static let outerSpacing: CGFloat = 12
+        static let innerSpacing: CGFloat = 8
+    }
     private let characterImageView: UIImageView = {
         let imageView = UIImageView()
         imageView.translatesAutoresizingMaskIntoConstraints = false
@@ -37,14 +42,14 @@ final class ListCharactersTableViewCell: UITableViewCell {
     
     private func addContraints() {
         NSLayoutConstraint.activate([
-            characterImageView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 12),
-            characterImageView.topAnchor.constraint(equalTo: topAnchor, constant: 12),
-            characterImageView.heightAnchor.constraint(equalToConstant: 80),
-            characterImageView.widthAnchor.constraint(equalToConstant: 80),
-            characterImageView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -12),
+            characterImageView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: Constants.outerSpacing),
+            characterImageView.topAnchor.constraint(equalTo: topAnchor, constant: Constants.outerSpacing),
+            characterImageView.heightAnchor.constraint(equalToConstant: Constants.imageSize),
+            characterImageView.widthAnchor.constraint(equalToConstant: Constants.imageSize),
+            characterImageView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -Constants.outerSpacing),
             
-            characterName.leadingAnchor.constraint(equalTo: characterImageView.trailingAnchor, constant: 12),
-            characterName.topAnchor.constraint(equalTo: characterImageView.topAnchor, constant: 8),
+            characterName.leadingAnchor.constraint(equalTo: characterImageView.trailingAnchor, constant: Constants.outerSpacing),
+            characterName.topAnchor.constraint(equalTo: characterImageView.topAnchor, constant: Constants.innerSpacing),
         ])
     }
     

--- a/WallaMarvel/Presentation/ListCharacter/ListCharactersViewController.swift
+++ b/WallaMarvel/Presentation/ListCharacter/ListCharactersViewController.swift
@@ -1,13 +1,22 @@
 import UIKit
 
 final class ListCharactersViewController: UIViewController {
+    private enum Constants {
+        static let paginationThreshold = 5
+    }
+
+    private enum Strings {
+        static let paginationErrorTitle = "Error loading more"
+        static let retry = "Retry"
+        static let dismiss = "Dismiss"
+    }
     var mainView: ListCharactersView { return view as! ListCharactersView }
 
     var presenter: ListCharactersPresenterProtocol?
     var listCharactersProvider: ListCharactersAdapter?
     weak var coordinator: ListCharactersCoordinatorProtocol?
 
-    private let paginationThreshold = 5
+    private let paginationThreshold = Constants.paginationThreshold
     private var isPaginatingFromScroll = false
 
     override func loadView() {
@@ -60,14 +69,14 @@ extension ListCharactersViewController: ListCharactersUI {
 
     func showPaginationError(_ error: AppError) {
         let alert = UIAlertController(
-            title: "Error loading more",
+            title: Strings.paginationErrorTitle,
             message: error.userMessage,
             preferredStyle: .alert
         )
-        alert.addAction(UIAlertAction(title: "Retry", style: .default) { [weak self] _ in
+        alert.addAction(UIAlertAction(title: Strings.retry, style: .default) { [weak self] _ in
             Task { [weak self] in await self?.presenter?.retryNextPage() }
         })
-        alert.addAction(UIAlertAction(title: "Dismiss", style: .cancel))
+        alert.addAction(UIAlertAction(title: Strings.dismiss, style: .cancel))
         present(alert, animated: true)
     }
 


### PR DESCRIPTION
## Summary

- Extracted all magic numbers and string literals into private `Constants` and `Strings` enums across all Presentation layer files
- Removed default dependency injection from all `init`s across DataSources, Repositories, UseCases, and Presenters
- Composition root moved exclusively to `SceneDelegate` (list flow) and `ListCharactersCoordinator.showDetail(for:)` (detail flow)

## Context

- Magic numbers and string literals were scattered across view files — changing a value (e.g. font size, spacing, label text) required hunting through method bodies
- All `init`s across DataSources, Repositories, UseCases, and Presenters had default concrete dependencies, violating DIP — each type knew its own concrete dependency instead of having it injected from outside
- `SceneDelegate` was building `ListCharactersPresenter()` with no visibility into the dependency chain

## Changes

- `DetailCharacterViewController.swift` — `private enum Constants` (11 layout values) + `private enum Strings` (10 texts)
- `ListCharactersView.swift` — `private enum Constants` (7 layout values) + `private enum Strings` (`"Retry"`) replacing old `enum Constant`
- `ListCharactersTableViewCell.swift` — `private enum Constants` (image size, spacing values)
- `ListCharactersViewController.swift` — `private enum Constants` (pagination threshold) + `private enum Strings` (alert title, action titles)
- `ListCharactersPresenter.swift` — `private enum Strings` (`"List of Characters"`)
- `CharacterDataSource`, `EpisodeDataSource` — removed `= APIClient()` default
- `CharacterRepository`, `EpisodeRepository` — removed DataSource defaults
- `GetCharacters`, `GetCharacterFirstEpisode` — removed Repository defaults
- `ListCharactersPresenter`, `DetailCharacterPresenter` — removed UseCase defaults
- `SceneDelegate.swift` — explicit dependency graph: `APIClient → DataSource → Repository → UseCase → Presenter`

## Tests

What was tested:

- No test changes required — all tests already inject dependencies explicitly via spies
- All existing test suites remain green

How it was validated:

- `BUILD SUCCEEDED` after every change
