### PR TITLE
[WP-09] Add VoiceOver accessibility support and fix cell label overflow

### DIFF
--- a/WallaMarvel/Presentation/ListCharacter/DetailCharacter/DetailCharacterViewController.swift
+++ b/WallaMarvel/Presentation/ListCharacter/DetailCharacter/DetailCharacterViewController.swift
@@ -177,6 +177,9 @@ final class DetailCharacterViewController: UIViewController {
         ])
         contentStack.addArrangedSubview(container)
 
+        imageView.isAccessibilityElement = false
+        container.isAccessibilityElement = false
+
         if let url = URL(string: character.imageURL) {
             imageView.kf.setImage(with: url, options: [.transition(.fade(Constants.imageFadeDuration)), .cacheOriginalImage])
         }
@@ -184,15 +187,17 @@ final class DetailCharacterViewController: UIViewController {
 
     private func addStatusBadge() {
         let status = character.status.lowercased()
-        let (text, color): (String, UIColor) = {
+        let (text, color, accessibleStatus): (String, UIColor, String) = {
             switch status {
-            case "alive": return (Strings.statusAlive, .systemGreen)
-            case "dead":  return (Strings.statusDead, .systemRed)
-            default:      return (Strings.statusUnknown, .systemGray)
+            case "alive": return (Strings.statusAlive, .systemGreen, "Alive")
+            case "dead":  return (Strings.statusDead, .systemRed, "Dead")
+            default:      return (Strings.statusUnknown, .systemGray, "Unknown")
             }
         }()
         statusBadge.text = "  \(text)  "
         statusBadge.backgroundColor = color
+        statusBadge.isAccessibilityElement = true
+        statusBadge.accessibilityLabel = "Status: \(accessibleStatus)"
 
         let container = UIView()
         container.addSubview(statusBadge)
@@ -229,17 +234,21 @@ final class DetailCharacterViewController: UIViewController {
         row.axis = .horizontal
         row.spacing = Constants.rowSpacing
         row.distribution = .equalSpacing
+        row.isAccessibilityElement = true
+        row.accessibilityLabel = "\(title): \(value)"
 
         let titleLabel = UILabel()
         titleLabel.text = title
         titleLabel.font = .systemFont(ofSize: Constants.rowFontSize, weight: .semibold)
         titleLabel.setContentHuggingPriority(.defaultHigh, for: .horizontal)
+        titleLabel.isAccessibilityElement = false
 
         let valueLabel = UILabel()
         valueLabel.text = value
         valueLabel.font = .systemFont(ofSize: Constants.rowFontSize)
         valueLabel.textAlignment = .right
         valueLabel.numberOfLines = 0
+        valueLabel.isAccessibilityElement = false
 
         row.addArrangedSubview(titleLabel)
         row.addArrangedSubview(valueLabel)
@@ -266,6 +275,8 @@ extension DetailCharacterViewController: DetailCharacterUI {
     func showEpisode(_ episode: Episode) {
         episodeLoadingIndicator.stopAnimating()
         episodeInfoLabel.text = "\(episode.name) (\(episode.code))\n\(episode.airDate)"
+        episodeInfoLabel.isAccessibilityElement = true
+        episodeInfoLabel.accessibilityLabel = "First seen in: \(episode.name) (\(episode.code)), \(episode.airDate)"
         episodeInfoLabel.isHidden = false
         episodeErrorLabel.isHidden = true
         retryButton.isHidden = true

--- a/WallaMarvel/Presentation/ListCharacter/DetailCharacter/DetailCharacterViewController.swift
+++ b/WallaMarvel/Presentation/ListCharacter/DetailCharacter/DetailCharacterViewController.swift
@@ -109,6 +109,7 @@ final class DetailCharacterViewController: UIViewController {
         button.setTitle(Strings.retry, for: .normal)
         button.addTarget(self, action: #selector(retryTapped), for: .touchUpInside)
         button.isHidden = true
+        button.accessibilityHint = "Activates to retry loading the episode"
         return button
     }()
 
@@ -288,6 +289,7 @@ extension DetailCharacterViewController: DetailCharacterUI {
         episodeErrorLabel.isHidden = false
         episodeInfoLabel.isHidden = true
         retryButton.isHidden = false
+        UIAccessibility.post(notification: .screenChanged, argument: episodeErrorLabel)
     }
 }
 

--- a/WallaMarvel/Presentation/ListCharacter/ListCharactersTableView.swift
+++ b/WallaMarvel/Presentation/ListCharacter/ListCharactersTableView.swift
@@ -66,6 +66,7 @@ final class ListCharactersView: UIView {
         button.backgroundColor = .systemBlue
         button.setTitleColor(.white, for: .normal)
         button.layer.cornerRadius = Constants.retryButtonCornerRadius
+        button.accessibilityHint = "Activates to reload the character list"
         return button
     }()
     
@@ -157,6 +158,7 @@ final class ListCharactersView: UIView {
         errorContainerView.isHidden = false
         bringSubviewToFront(errorContainerView)
         errorLabel.text = message
+        UIAccessibility.post(notification: .screenChanged, argument: errorLabel)
     }
 
     func setRetryEnabled(_ isEnabled: Bool) {

--- a/WallaMarvel/Presentation/ListCharacter/ListCharactersTableViewCell.swift
+++ b/WallaMarvel/Presentation/ListCharacter/ListCharactersTableViewCell.swift
@@ -33,6 +33,14 @@ final class ListCharactersTableViewCell: UITableViewCell {
     private func setup() {
         addSubviews()
         addContraints()
+        setupAccessibility()
+    }
+
+    private func setupAccessibility() {
+        isAccessibilityElement = true
+        accessibilityHint = "Double tap to see more details"
+        characterImageView.isAccessibilityElement = false
+        characterName.isAccessibilityElement = false
     }
     
     private func addSubviews() {
@@ -49,12 +57,15 @@ final class ListCharactersTableViewCell: UITableViewCell {
             characterImageView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -Constants.outerSpacing),
             
             characterName.leadingAnchor.constraint(equalTo: characterImageView.trailingAnchor, constant: Constants.outerSpacing),
+            characterName.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -Constants.outerSpacing),
             characterName.topAnchor.constraint(equalTo: characterImageView.topAnchor, constant: Constants.innerSpacing),
+            characterName.centerYAnchor.constraint(equalTo: characterImageView.centerYAnchor),
         ])
     }
     
     func configure(model: Character) {
         characterImageView.kf.setImage(with: URL(string: model.imageURL))
         characterName.text = model.name
+        accessibilityLabel = "Character: \(model.name)."
     }
 }


### PR DESCRIPTION
## Summary

- Added VoiceOver accessibility to `ListCharactersTableViewCell`: cell reads as a single element with a composed label and hint
- Added VoiceOver accessibility to `DetailCharacterViewController`: image skipped, status badge with clean label, info rows and episode section each read as a single accessible element
- Fixed `characterName` label overflowing horizontally in the cell due to missing `trailingAnchor` constraint

## Context

- The app had no VoiceOver support — running with screen reader active produced a poor experience on both screens
- On the list, VoiceOver was announcing the image and the name as separate, unrelated elements
- On the detail screen, info row sub-labels were individually focusable but semantically disconnected; the status badge was read with the raw bullet character `●`; the image was being announced unnecessarily
- `characterName` had no `trailingAnchor`, so Auto Layout could not calculate the label's width and text would overflow beyond the cell boundary instead of wrapping

## Evidences

https://github.com/user-attachments/assets/481a84c7-66ab-442b-b870-309fc3eba33b

## Changes

- `ListCharactersTableViewCell.swift`
  - `isAccessibilityElement = true` on the cell; `false` on image and name label
  - `accessibilityLabel` composed as `"Character: <name>."` in `configure(model:)`
  - `accessibilityHint` set to `"Double tap to see more details"`
  - Added `trailingAnchor` and `centerYAnchor` constraints to `characterName`

- `DetailCharacterViewController.swift`
  - Image and its container marked `isAccessibilityElement = false`
  - Status badge reads `"Status: Alive"` / `"Status: Dead"` / `"Status: Unknown"` — bullet stripped, clean plain text
  - `makeInfoRow(title:value:)` — row `UIStackView` is the single accessible element with `accessibilityLabel = "\(title): \(value)"`; sub-labels marked non-accessible
  - `showEpisode(_:)` — `episodeInfoLabel.accessibilityLabel` composed as `"First seen in: \(name) (\(code)), \(airDate)"`

## Tests

What was tested:
- No new unit tests — changes are isolated to the UI/presentation layer with no business logic

How it was validated:
- VoiceOver manually verified on simulator for both screens
- No compile errors in modified files
- All existing tests remain green