### PR TITLE
[WP-13] Add local character search with empty state

### DIFF
--- a/WallaMarvel/Presentation/ListCharacter/ListCharactersPresenter.swift
+++ b/WallaMarvel/Presentation/ListCharacter/ListCharactersPresenter.swift
@@ -7,6 +7,8 @@ protocol ListCharactersPresenterProtocol: AnyObject {
     func getCharacters() async
     func loadNextPage() async
     func retryNextPage() async
+    func searchCharacters(name: String)
+    func clearSearch()
 }
 
 @MainActor
@@ -19,6 +21,7 @@ protocol ListCharactersUI: AnyObject {
     func hidePaginationLoading()
     func showError(_ error: AppError)
     func showPaginationError(_ error: AppError)
+    func showEmptySearch()
 }
 
 @MainActor
@@ -34,6 +37,8 @@ final class ListCharactersPresenter: ListCharactersPresenterProtocol {
     private var hasNextPage = false
     private var isLoadingPage = false
     private var isPaginationBlocked = false
+    private var allCharacters: [Character] = []
+    private var isSearchActive = false
 
     init(getCharactersUseCase: GetCharactersUseCaseProtocol) {
         self.getCharactersUseCase = getCharactersUseCase
@@ -49,12 +54,15 @@ final class ListCharactersPresenter: ListCharactersPresenterProtocol {
         hasNextPage = false
         isLoadingPage = false
         isPaginationBlocked = false
+        isSearchActive = false
+        allCharacters = []
 
         do {
             let page = try await getCharactersUseCase.execute(page: currentPage)
             hasNextPage = page.hasNextPage
+            allCharacters = page.characters
             ui?.hideLoading()
-            ui?.update(characters: page.characters)
+            ui?.update(characters: allCharacters)
         } catch let error as AppError {
             ui?.hideLoading()
             ui?.showError(error)
@@ -65,7 +73,7 @@ final class ListCharactersPresenter: ListCharactersPresenterProtocol {
     }
 
     func loadNextPage() async {
-        guard !isLoadingPage, hasNextPage, !isPaginationBlocked else { return }
+        guard !isLoadingPage, hasNextPage, !isPaginationBlocked, !isSearchActive else { return }
 
         isLoadingPage = true
         ui?.showPaginationLoading()
@@ -74,6 +82,7 @@ final class ListCharactersPresenter: ListCharactersPresenterProtocol {
             let page = try await getCharactersUseCase.execute(page: currentPage + 1)
             currentPage += 1
             hasNextPage = page.hasNextPage
+            allCharacters.append(contentsOf: page.characters)
             ui?.appendCharacters(page.characters)
         } catch let error as AppError {
             isPaginationBlocked = true
@@ -90,5 +99,27 @@ final class ListCharactersPresenter: ListCharactersPresenterProtocol {
     func retryNextPage() async {
         isPaginationBlocked = false
         await loadNextPage()
+    }
+
+    func searchCharacters(name: String) {
+        let query = name.trimmingCharacters(in: .whitespaces)
+        guard !query.isEmpty else {
+            clearSearch()
+            return
+        }
+        isSearchActive = true
+        let filtered = allCharacters.filter {
+            $0.name.localizedCaseInsensitiveContains(query)
+        }
+        if filtered.isEmpty {
+            ui?.showEmptySearch()
+        } else {
+            ui?.update(characters: filtered)
+        }
+    }
+
+    func clearSearch() {
+        isSearchActive = false
+        ui?.update(characters: allCharacters)
     }
 }

--- a/WallaMarvel/Presentation/ListCharacter/ListCharactersTableView.swift
+++ b/WallaMarvel/Presentation/ListCharacter/ListCharactersTableView.swift
@@ -11,10 +11,15 @@ final class ListCharactersView: UIView {
         static let retryButtonHeight: CGFloat = 44
         static let retryButtonCornerRadius: CGFloat = 8
         static let fontSize: CGFloat = 16
+        static let emptySearchIconSize: CGFloat = 60
+        static let emptySearchSpacing: CGFloat = 16
+        static let emptySearchHorizontalInset: CGFloat = 32
     }
 
     private enum Strings {
         static let retry = "Retry"
+        static let emptySearchTitle = "No characters found"
+        static let emptySearchMessage = "Try a different name."
     }
     
     private let charactersTableView: UITableView = {
@@ -46,6 +51,47 @@ final class ListCharactersView: UIView {
         view.backgroundColor = .systemBackground
         view.isHidden = true
         return view
+    }()
+
+    private let emptySearchContainerView: UIView = {
+        let view = UIView()
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.backgroundColor = .systemBackground
+        view.isHidden = true
+        view.accessibilityElements = []
+        return view
+    }()
+
+    private let emptySearchIconView: UIImageView = {
+        let image = UIImageView(image: UIImage(systemName: "magnifyingglass"))
+        image.translatesAutoresizingMaskIntoConstraints = false
+        image.tintColor = .secondaryLabel
+        image.contentMode = .scaleAspectFit
+        image.isAccessibilityElement = false
+        return image
+    }()
+
+    private let emptySearchTitleLabel: UILabel = {
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.text = Strings.emptySearchTitle
+        label.font = UIFont.systemFont(ofSize: 18, weight: .semibold)
+        label.textAlignment = .center
+        label.textColor = .label
+        label.isAccessibilityElement = false
+        return label
+    }()
+
+    private let emptySearchMessageLabel: UILabel = {
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.text = Strings.emptySearchMessage
+        label.font = UIFont.systemFont(ofSize: 15)
+        label.textAlignment = .center
+        label.textColor = .secondaryLabel
+        label.numberOfLines = 0
+        label.isAccessibilityElement = false
+        return label
     }()
     
     private let errorLabel: UILabel = {
@@ -87,11 +133,15 @@ final class ListCharactersView: UIView {
     private func addSubviews() {
         addSubview(charactersTableView)
         addSubview(errorContainerView)
+        addSubview(emptySearchContainerView)
         addSubview(loadingView)
-        
+
         loadingView.addSubview(loadingIndicator)
         errorContainerView.addSubview(errorLabel)
         errorContainerView.addSubview(retryButton)
+        emptySearchContainerView.addSubview(emptySearchIconView)
+        emptySearchContainerView.addSubview(emptySearchTitleLabel)
+        emptySearchContainerView.addSubview(emptySearchMessageLabel)
     }
     
     private func addContraints() {
@@ -122,6 +172,24 @@ final class ListCharactersView: UIView {
             retryButton.centerXAnchor.constraint(equalTo: errorContainerView.centerXAnchor),
             retryButton.widthAnchor.constraint(equalToConstant: Constants.retryButtonWidth),
             retryButton.heightAnchor.constraint(equalToConstant: Constants.retryButtonHeight),
+
+            emptySearchContainerView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            emptySearchContainerView.trailingAnchor.constraint(equalTo: trailingAnchor),
+            emptySearchContainerView.topAnchor.constraint(equalTo: topAnchor),
+            emptySearchContainerView.bottomAnchor.constraint(equalTo: bottomAnchor),
+
+            emptySearchIconView.centerXAnchor.constraint(equalTo: emptySearchContainerView.centerXAnchor),
+            emptySearchIconView.centerYAnchor.constraint(equalTo: emptySearchContainerView.centerYAnchor, constant: -Constants.emptySearchSpacing * 2),
+            emptySearchIconView.widthAnchor.constraint(equalToConstant: Constants.emptySearchIconSize),
+            emptySearchIconView.heightAnchor.constraint(equalToConstant: Constants.emptySearchIconSize),
+
+            emptySearchTitleLabel.topAnchor.constraint(equalTo: emptySearchIconView.bottomAnchor, constant: Constants.emptySearchSpacing),
+            emptySearchTitleLabel.leadingAnchor.constraint(equalTo: emptySearchContainerView.leadingAnchor, constant: Constants.emptySearchHorizontalInset),
+            emptySearchTitleLabel.trailingAnchor.constraint(equalTo: emptySearchContainerView.trailingAnchor, constant: -Constants.emptySearchHorizontalInset),
+
+            emptySearchMessageLabel.topAnchor.constraint(equalTo: emptySearchTitleLabel.bottomAnchor, constant: Constants.emptySearchSpacing / 2),
+            emptySearchMessageLabel.leadingAnchor.constraint(equalTo: emptySearchContainerView.leadingAnchor, constant: Constants.emptySearchHorizontalInset),
+            emptySearchMessageLabel.trailingAnchor.constraint(equalTo: emptySearchContainerView.trailingAnchor, constant: -Constants.emptySearchHorizontalInset),
         ])
     }
 
@@ -132,6 +200,7 @@ final class ListCharactersView: UIView {
 
     func showLoading() {
         errorContainerView.isHidden = true
+        emptySearchContainerView.isHidden = true
         charactersTableView.isHidden = true
         loadingView.isHidden = false
         bringSubviewToFront(loadingView)
@@ -145,10 +214,20 @@ final class ListCharactersView: UIView {
 
     func showCharacters() {
         errorContainerView.isHidden = true
+        emptySearchContainerView.isHidden = true
         loadingIndicator.stopAnimating()
         loadingView.isHidden = true
         charactersTableView.isHidden = false
         bringSubviewToFront(charactersTableView)
+    }
+
+    func showEmptySearch() {
+        charactersTableView.isHidden = true
+        emptySearchContainerView.isHidden = false
+        bringSubviewToFront(emptySearchContainerView)
+        emptySearchContainerView.isAccessibilityElement = true
+        emptySearchContainerView.accessibilityLabel = "\(Strings.emptySearchTitle). \(Strings.emptySearchMessage)"
+        UIAccessibility.post(notification: .screenChanged, argument: emptySearchContainerView)
     }
 
     func showError(message: String) {

--- a/WallaMarvel/Presentation/ListCharacter/ListCharactersViewController.swift
+++ b/WallaMarvel/Presentation/ListCharacter/ListCharactersViewController.swift
@@ -9,6 +9,8 @@ final class ListCharactersViewController: UIViewController {
         static let paginationErrorTitle = "Error loading more"
         static let retry = "Retry"
         static let dismiss = "Dismiss"
+        static let searchPlaceholder = "Search characters"
+        static let searchAccessibilityLabel = "Search characters"
     }
     var mainView: ListCharactersView { return view as! ListCharactersView }
 
@@ -18,6 +20,15 @@ final class ListCharactersViewController: UIViewController {
 
     private let paginationThreshold = Constants.paginationThreshold
     private var isPaginatingFromScroll = false
+    private var searchDebounceTask: Task<Void, Never>?
+
+    private let searchController: UISearchController = {
+        let sc = UISearchController(searchResultsController: nil)
+        sc.obscuresBackgroundDuringPresentation = false
+        sc.searchBar.placeholder = Strings.searchPlaceholder
+        sc.searchBar.accessibilityLabel = Strings.searchAccessibilityLabel
+        return sc
+    }()
 
     override func loadView() {
         view = ListCharactersView()
@@ -32,6 +43,15 @@ final class ListCharactersViewController: UIViewController {
         }
 
         title = presenter?.screenTitle()
+        setupSearchController()
+    }
+
+    private func setupSearchController() {
+        searchController.searchResultsUpdater = self
+        searchController.searchBar.delegate = self
+        navigationItem.searchController = searchController
+        navigationItem.hidesSearchBarWhenScrolling = true
+        definesPresentationContext = true
     }
 }
 
@@ -80,6 +100,10 @@ extension ListCharactersViewController: ListCharactersUI {
         present(alert, animated: true)
     }
 
+    func showEmptySearch() {
+        mainView.showEmptySearch()
+    }
+
     @objc
     private func handleRetryTap() {
         mainView.setRetryEnabled(false)
@@ -104,5 +128,30 @@ extension ListCharactersViewController: UITableViewDelegate {
             await self?.presenter?.loadNextPage()
             self?.isPaginatingFromScroll = false
         }
+    }
+}
+
+extension ListCharactersViewController: UISearchResultsUpdating {
+    func updateSearchResults(for searchController: UISearchController) {
+        let query = searchController.searchBar.text ?? ""
+        searchDebounceTask?.cancel()
+        searchDebounceTask = Task { @MainActor [weak self] in
+            try? await Task.sleep(nanoseconds: 500_000_000)
+            guard !Task.isCancelled else { return }
+            if query.trimmingCharacters(in: .whitespaces).isEmpty {
+                self?.presenter?.clearSearch()
+                self?.mainView.showCharacters()
+            } else {
+                self?.presenter?.searchCharacters(name: query)
+            }
+        }
+    }
+}
+
+extension ListCharactersViewController: UISearchBarDelegate {
+    func searchBarCancelButtonClicked(_ searchBar: UISearchBar) {
+        searchDebounceTask?.cancel()
+        presenter?.clearSearch()
+        mainView.showCharacters()
     }
 }

--- a/WallaMarvelTests/Presentation/ListCharactersPresenterTests.swift
+++ b/WallaMarvelTests/Presentation/ListCharactersPresenterTests.swift
@@ -236,4 +236,100 @@ final class ListCharactersPresenterTests: XCTestCase {
         XCTAssertTrue(getCharactersUseCaseSpy.executeCalled)
         XCTAssertEqual(uiSpy.appendedCharacters.count, 1)
     }
+
+    // MARK: - searchCharacters
+
+    func test_whenSearchCharacters_withMatchingName_shouldUpdateUIWithFilteredResults() async {
+        let morty = Character.fixture(id: 1, name: "Morty Smith")
+        let rick = Character.fixture(id: 2, name: "Rick Sanchez")
+        getCharactersUseCaseSpy.pageResult = CharactersPage(characters: [morty, rick], hasNextPage: false)
+        let uiSpy = ListCharactersUISpy()
+        sut.ui = uiSpy
+
+        await sut.getCharacters()
+        sut.searchCharacters(name: "Morty")
+
+        XCTAssertEqual(uiSpy.updatedCharacters.count, 1)
+        XCTAssertEqual(uiSpy.updatedCharacters.first?.name, "Morty Smith")
+    }
+
+    func test_whenSearchCharacters_isCaseInsensitive() async {
+        let morty = Character.fixture(id: 1, name: "Morty Smith")
+        let rick = Character.fixture(id: 2, name: "Rick Sanchez")
+        getCharactersUseCaseSpy.pageResult = CharactersPage(characters: [morty, rick], hasNextPage: false)
+        let uiSpy = ListCharactersUISpy()
+        sut.ui = uiSpy
+
+        await sut.getCharacters()
+        sut.searchCharacters(name: "morty")
+
+        XCTAssertEqual(uiSpy.updatedCharacters.count, 1)
+        XCTAssertEqual(uiSpy.updatedCharacters.first?.name, "Morty Smith")
+    }
+
+    func test_whenSearchCharacters_withNoMatch_shouldShowEmptySearch() async {
+        let morty = Character.fixture(id: 1, name: "Morty Smith")
+        getCharactersUseCaseSpy.pageResult = CharactersPage(characters: [morty], hasNextPage: false)
+        let uiSpy = ListCharactersUISpy()
+        sut.ui = uiSpy
+
+        await sut.getCharacters()
+        sut.searchCharacters(name: "Zorg")
+
+        XCTAssertTrue(uiSpy.showEmptySearchWasCalled)
+    }
+
+    func test_whenSearchCharacters_withEmptyString_shouldRestoreFullList() async {
+        let morty = Character.fixture(id: 1, name: "Morty Smith")
+        let rick = Character.fixture(id: 2, name: "Rick Sanchez")
+        getCharactersUseCaseSpy.pageResult = CharactersPage(characters: [morty, rick], hasNextPage: false)
+        let uiSpy = ListCharactersUISpy()
+        sut.ui = uiSpy
+
+        await sut.getCharacters()
+        sut.searchCharacters(name: "Morty")
+        sut.searchCharacters(name: "")
+
+        XCTAssertEqual(uiSpy.updatedCharacters.count, 2)
+    }
+
+    func test_whenSearchCharacters_withWhitespaceOnly_shouldRestoreFullList() async {
+        let morty = Character.fixture(id: 1, name: "Morty Smith")
+        getCharactersUseCaseSpy.pageResult = CharactersPage(characters: [morty], hasNextPage: false)
+        let uiSpy = ListCharactersUISpy()
+        sut.ui = uiSpy
+
+        await sut.getCharacters()
+        sut.searchCharacters(name: "   ")
+
+        XCTAssertEqual(uiSpy.updatedCharacters.count, 1)
+    }
+
+    func test_whenClearSearch_shouldRestoreFullList() async {
+        let morty = Character.fixture(id: 1, name: "Morty Smith")
+        let rick = Character.fixture(id: 2, name: "Rick Sanchez")
+        getCharactersUseCaseSpy.pageResult = CharactersPage(characters: [morty, rick], hasNextPage: false)
+        let uiSpy = ListCharactersUISpy()
+        sut.ui = uiSpy
+
+        await sut.getCharacters()
+        sut.searchCharacters(name: "Morty")
+        sut.clearSearch()
+
+        XCTAssertEqual(uiSpy.updatedCharacters.count, 2)
+    }
+
+    func test_whenLoadNextPage_withSearchActive_shouldNotCallUseCase() async {
+        getCharactersUseCaseSpy.pageResult = CharactersPage(characters: [.fixture()], hasNextPage: true)
+        let uiSpy = ListCharactersUISpy()
+        sut.ui = uiSpy
+
+        await sut.getCharacters()
+        sut.searchCharacters(name: "Morty")
+        getCharactersUseCaseSpy.resetCallTracking()
+
+        await sut.loadNextPage()
+
+        XCTAssertFalse(getCharactersUseCaseSpy.executeCalled)
+    }
 }

--- a/WallaMarvelTests/Spies/ListCharactersPresenterSpy.swift
+++ b/WallaMarvelTests/Spies/ListCharactersPresenterSpy.swift
@@ -6,6 +6,9 @@ final class ListCharactersPresenterSpy: ListCharactersPresenterProtocol {
     private(set) var getCharactersCalled = false
     private(set) var loadNextPageCalled = false
     private(set) var retryNextPageCalled = false
+    private(set) var searchCharactersCalled = false
+    private(set) var lastSearchedName: String?
+    private(set) var clearSearchCalled = false
 
     func screenTitle() -> String {
         screenTitleCalled = true
@@ -22,5 +25,14 @@ final class ListCharactersPresenterSpy: ListCharactersPresenterProtocol {
 
     func retryNextPage() async {
         retryNextPageCalled = true
+    }
+
+    func searchCharacters(name: String) {
+        searchCharactersCalled = true
+        lastSearchedName = name
+    }
+
+    func clearSearch() {
+        clearSearchCalled = true
     }
 }

--- a/WallaMarvelTests/Spies/ListCharactersUISpy.swift
+++ b/WallaMarvelTests/Spies/ListCharactersUISpy.swift
@@ -3,6 +3,7 @@ import XCTest
 
 final class ListCharactersUISpy: ListCharactersUI {
     private(set) var updatedCharactersCount: Int?
+    private(set) var updatedCharacters: [Character] = []
     private(set) var appendedCharacters: [Character] = []
     private(set) var lastShownError: AppError?
     private(set) var lastPaginationError: AppError?
@@ -11,6 +12,7 @@ final class ListCharactersUISpy: ListCharactersUI {
     private(set) var hideLoadingWasCalled: Bool = false
     private(set) var isPaginationLoadingShown: Bool = false
     private(set) var showPaginationLoadingWasCalled: Bool = false
+    private(set) var showEmptySearchWasCalled: Bool = false
     private let updateExpectation: XCTestExpectation?
 
     init(updateExpectation: XCTestExpectation? = nil) {
@@ -28,6 +30,7 @@ final class ListCharactersUISpy: ListCharactersUI {
     }
 
     func update(characters: [Character]) {
+        updatedCharacters = characters
         updatedCharactersCount = characters.count
         updateExpectation?.fulfill()
     }
@@ -51,5 +54,9 @@ final class ListCharactersUISpy: ListCharactersUI {
 
     func showPaginationError(_ error: AppError) {
         lastPaginationError = error
+    }
+
+    func showEmptySearch() {
+        showEmptySearchWasCalled = true
     }
 }


### PR DESCRIPTION
## Summary

- Added `UISearchController` to the character list screen with debounce via Swift Concurrency
- Implemented local filtering over already-loaded characters - no new API requests
- Added empty state screen when search returns no results
- Pagination is blocked while search is active
- All hardcoded strings moved to `Strings` enum
- VoiceOver support added to search bar, empty state, and search cancel

## Context

- The list screen had no search capability
- Filtering against the API would require a new request on every keystroke - unnecessary network overhead since all pages are already in memory
- Without a debounce, rapid typing would trigger excessive UI updates
- No empty state existed to give feedback when a search yields no results

## Evidences

| Search | Not found | 
|--------|--------|
| <img width="200" alt="Simulator Screenshot - iPhone 17 Pro - 2026-04-03 at 19 26 35" src="https://github.com/user-attachments/assets/3126a5e0-39a6-4117-9e25-f0c0dd1af5d7" />| <img width="200" alt="Simulator Screenshot - iPhone 17 Pro - 2026-04-03 at 19 26 23" src="https://github.com/user-attachments/assets/89488f3b-94b4-456a-ae5d-e65f91b72112" /> | 

## Changes

- `ListCharactersPresenterProtocol` - added `searchCharacters(name:)` and `clearSearch()`
- `ListCharactersUI` - added `showEmptySearch()`
- `ListCharactersPresenter`
  - `allCharacters` accumulates all loaded characters across pages
  - `isSearchActive` flag blocks pagination during search
  - `searchCharacters(name:)` - trims whitespace, delegates to `clearSearch()` if empty, filters with `localizedCaseInsensitiveContains`, calls `showEmptySearch()` on no match
  - `clearSearch()` - restores full list without a new request
  - `getCharacters()` resets `allCharacters` and `isSearchActive` on fresh load
  - `loadNextPage()` accumulates new pages into `allCharacters`
- `ListCharactersViewController`
  - `UISearchController` added to `navigationItem`
  - Debounce of 500ms via cancellable `Task` in `updateSearchResults`
  - `searchBarCancelButtonClicked` cancels pending debounce and restores list immediately
  - Search strings (`placeholder`, `accessibilityLabel`) moved to `Strings` enum
- `ListCharactersView`
  - Empty state with SF Symbol `magnifyingglass`, title and message labels
  - `showEmptySearch()` reveals container, sets composed `accessibilityLabel`, posts `UIAccessibility.screenChanged` to move VoiceOver focus
  - `showCharacters()` and `showLoading()` updated to hide empty state
- `ListCharactersUISpy` - added `showEmptySearchWasCalled`, `updatedCharacters`
- `ListCharactersPresenterSpy` - added `searchCharactersCalled`, `lastSearchedName`, `clearSearchCalled`

## Tests

What was tested:
- `test_whenSearchCharacters_withMatchingName_shouldUpdateUIWithFilteredResults`
- `test_whenSearchCharacters_isCaseInsensitive`
- `test_whenSearchCharacters_withNoMatch_shouldShowEmptySearch`
- `test_whenSearchCharacters_withEmptyString_shouldRestoreFullList`
- `test_whenSearchCharacters_withWhitespaceOnly_shouldRestoreFullList`
- `test_whenClearSearch_shouldRestoreFullList`
- `test_whenLoadNextPage_withSearchActive_shouldNotCallUseCase`

How it was validated:
- All existing tests remain green
- No compile errors in modified files