### PR TITLE
[WP-15] Improve character list cell visual consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,16 @@ The project was received with **Marvel API** integration via `URLSession`, using
 
 ---
 
+### WP-15 — Visual Polish: Placeholder and Circular Images
+
+**`ListCharactersTableViewCell`:**
+- Placeholder (`person.crop.circle.fill`) displayed while Kingfisher loads the character thumbnail, preventing empty space during network requests
+- `contentMode = .scaleAspectFill` and `clipsToBounds = true` applied to the image view for correct cropping inside the fixed frame
+- Circular corner radius (`40pt` — half of the 80pt image size), consistent with the style already used on the detail screen
+- `placeholderImage` and `accessibilityHint` string literals moved to `private enum Strings`, completing the Constants/Strings enum discipline applied in WP-12
+
+---
+
 ## Technical Decisions
 
 ### Local filter vs. API search

--- a/WallaMarvel/Presentation/ListCharacter/ListCharactersTableViewCell.swift
+++ b/WallaMarvel/Presentation/ListCharacter/ListCharactersTableViewCell.swift
@@ -5,12 +5,22 @@ import Kingfisher
 final class ListCharactersTableViewCell: UITableViewCell {
     private enum Constants {
         static let imageSize: CGFloat = 80
+        static let imageCornerRadius: CGFloat = 40
         static let outerSpacing: CGFloat = 12
         static let innerSpacing: CGFloat = 8
+    }
+
+    private enum Strings {
+        static let placeholderImage = "person.crop.circle.fill"
+        static let accessibilityHint = "Double tap to see more details"
     }
     private let characterImageView: UIImageView = {
         let imageView = UIImageView()
         imageView.translatesAutoresizingMaskIntoConstraints = false
+        imageView.contentMode = .scaleAspectFill
+        imageView.clipsToBounds = true
+        imageView.tintColor = .systemGray3
+        imageView.layer.cornerRadius = Constants.imageCornerRadius
         return imageView
     }()
     
@@ -38,7 +48,7 @@ final class ListCharactersTableViewCell: UITableViewCell {
 
     private func setupAccessibility() {
         isAccessibilityElement = true
-        accessibilityHint = "Double tap to see more details"
+        accessibilityHint = Strings.accessibilityHint
         characterImageView.isAccessibilityElement = false
         characterName.isAccessibilityElement = false
     }
@@ -64,7 +74,8 @@ final class ListCharactersTableViewCell: UITableViewCell {
     }
     
     func configure(model: Character) {
-        characterImageView.kf.setImage(with: URL(string: model.imageURL))
+        let placeholder = UIImage(systemName: Strings.placeholderImage)
+        characterImageView.kf.setImage(with: URL(string: model.imageURL), placeholder: placeholder)
         characterName.text = model.name
         accessibilityLabel = "Character: \(model.name)."
     }


### PR DESCRIPTION
## Summary

- Added placeholder image while character photo loads in the list screen
- Added circular corner radius to character image in the list cell to match the detail screen style
- Added `contentMode = .scaleAspectFill` and `clipsToBounds = true` to correctly fill the image bounds

## Context

- While the image was loading, the cell showed a blank space — no visual feedback for the user
- The detail screen already displayed circular images, but the list screen did not — visual inconsistency between the two screens

## Changes

- `ListCharactersTableViewCell.swift`
  - Added `imageCornerRadius = 40` to `Constants` (half of `imageSize = 80` — produces a perfect circle)
  - `characterImageView` configured with `contentMode = .scaleAspectFill`, `clipsToBounds = true`, `tintColor = .systemGray3`, `layer.cornerRadius = Constants.imageCornerRadius`
  - `configure(model:)` updated to pass `UIImage(systemName: "person.crop.circle.fill")` as Kingfisher placeholde

## Notes

- Placeholder uses SF Symbols — no external assets required
- `cornerRadius` value kept in `Constants` following the existing pattern in the file