### PR TITLE
[WP-16] improve font size visibility when ipad/ios

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,22 @@ The project was received with **Marvel API** integration via `URLSession`, using
 - Circular corner radius (`40pt` — half of the 80pt image size), consistent with the style already used on the detail screen
 - `placeholderImage` and `accessibilityHint` string literals moved to `private enum Strings`, completing the Constants/Strings enum discipline applied in WP-12
 
+---
+
+### WP-16 — iPad Adaptive Typography and Image Sizing
+
+**Font scaling (`UIFont+Adaptive.swift`):**
+- Created `UIFont.adaptive(textStyle:weight:)` — a single extension method replacing all `UIFont.systemFont(ofSize:)` and `UIFont.preferredFont(forTextStyle:)` calls across the presentation layer
+- On iPhone: uses the standard `preferredFont(forTextStyle:)` point size
+- On iPad: multiplies the base point size by `1.4` before wrapping with `UIFontMetrics` — producing noticeably larger text without hardcoding device-specific values
+- Dynamic Type (user accessibility settings) continues to work on both devices via `UIFontMetrics.scaledFont(for:)` and `adjustsFontForContentSizeCategory = true`
+- Applied to: `ListCharactersTableViewCell`, `ListCharactersTableView`, `DetailCharacterViewController`
+
+**Image sizing (`DetailCharacterViewController`):**
+- `imageSize` promoted from a fixed `CGFloat` constant to a computed value: `300pt` on iPad, `200pt` on iPhone
+- `imageCornerRadius` derived automatically as `imageSize / 2` — always correct regardless of device
+- `cornerRadius` applied at layout time (`addImageView()`) instead of at property declaration, ensuring the correct value is used
+
 ## Technical Decisions
 ### Local filter vs. API search
 The search bar filters characters already loaded in memory instead of making a new API request on each keystroke. Since the app already paginates and accumulates all characters in `allCharacters`, querying the network again would be wasteful and would add latency with no real benefit for the user.
@@ -176,6 +192,12 @@ When an error state appears, `.screenChanged` is posted instead of `.announcemen
 
 ### Accessibility labels in the View layer
 `accessibilityLabel` composition (e.g. `"Character: Morty Smith."`) is intentionally kept in the View layer. These strings are UI and platform conventions, not business rules — there is no logic to test and no reason to involve the Presenter.
+
+### `UIFont.adaptive` — single font entry point for iPhone and iPad
+`UIFont.preferredFont(forTextStyle:)` returns the same base point size on both iPhone and iPad — Dynamic Type only scales with the user's accessibility preference, not with the device class. To address this, all font assignments go through `UIFont.adaptive(textStyle:weight:)`, a thin extension that applies a `1.4×` multiplier on iPad before wrapping the result with `UIFontMetrics`. This keeps every call site uniform, avoids scattered `UIDevice` checks across multiple files, and preserves Dynamic Type on both devices.
+
+### Adaptive image size via computed constant
+Rather than maintaining separate size values for iPhone and iPad, `DetailCharacterViewController` exposes `Constants.imageSize` as a computed property (`300pt` on iPad, `200pt` on iPhone`) and derives `imageCornerRadius` as `imageSize / 2`. The layout code is unchanged — the device decision is fully contained in the constant.
 
 ## Test Coverage
 Patterns used:

--- a/WallaMarvel.xcodeproj/project.pbxproj
+++ b/WallaMarvel.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		AA9F1234567BCDEF12345678 /* UIFont+Adaptive.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB9F1234567BCDEF12345678 /* UIFont+Adaptive.swift */; };
 		0032C06B0B130FE8301D5B4B /* EpisodeDataSourceSpy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D17CFACB97F14547FDA15DA /* EpisodeDataSourceSpy.swift */; };
 		07B2C0EEDB0C6721A19AA357 /* EpisodeDataModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0291A77268CD1B64903B8E99 /* EpisodeDataModel.swift */; };
 		0D6A93A4DA0047F880E557F5 /* AppCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81E290EAA75A481AABB9C916 /* AppCoordinatorTests.swift */; };
@@ -130,6 +131,7 @@
 		1A3B7327286ADEE6007BF626 /* ListCharactersTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListCharactersTableViewCell.swift; sourceTree = "<group>"; };
 		1A3B7329286AE195007BF626 /* ListCharactersAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListCharactersAdapter.swift; sourceTree = "<group>"; };
 		1A7B9BBE286D81B600EBC1A6 /* Thumbnail.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Thumbnail.swift; sourceTree = "<group>"; };
+		BB9F1234567BCDEF12345678 /* UIFont+Adaptive.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "UIFont+Adaptive.swift"; sourceTree = "<group>"; };
 		1A8026D70B99D566B4C16C59 /* EpisodeRepository.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = EpisodeRepository.swift; sourceTree = "<group>"; };
 		1A821EC82862FE3C0024D397 /* APIClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIClient.swift; sourceTree = "<group>"; };
 		1A821ED3286302EC0024D397 /* CharacterResponseDataModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CharacterResponseDataModel.swift; sourceTree = "<group>"; };
@@ -359,10 +361,19 @@
 		1A8F39CD2F7DF583005F4921 /* Presentation */ = {
 			isa = PBXGroup;
 			children = (
+				CC9F1234567BCDEF12345678 /* Extensions */,
 				9F11DE6BE37B4086AF398B8F /* Coordinators */,
 				1A821EC42862FD470024D397 /* ListCharacter */,
 			);
 			path = Presentation;
+			sourceTree = "<group>";
+		};
+		CC9F1234567BCDEF12345678 /* Extensions */ = {
+			isa = PBXGroup;
+			children = (
+				BB9F1234567BCDEF12345678 /* UIFont+Adaptive.swift */,
+			);
+			path = Extensions;
 			sourceTree = "<group>";
 		};
 		1AA67B832F7E13FE002C7F2E /* Domain */ = {
@@ -709,6 +720,7 @@
 				47BF94B22A989A3D4450CD3C /* EpisodeDataSource.swift in Sources */,
 				81C6CDB86EAFB60DE88A63DC /* GetEpisodeRequest.swift in Sources */,
 				565172C41918A3AF9B8FFF82 /* DetailCharacterPresenter.swift in Sources */,
+				AA9F1234567BCDEF12345678 /* UIFont+Adaptive.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/WallaMarvel/Presentation/Extensions/UIFont+Adaptive.swift
+++ b/WallaMarvel/Presentation/Extensions/UIFont+Adaptive.swift
@@ -1,0 +1,13 @@
+import UIKit
+
+extension UIFont {
+    static func adaptive(textStyle: TextStyle, weight: Weight? = nil) -> UIFont {
+        let baseSize = UIFont.preferredFont(forTextStyle: textStyle).pointSize
+        let resolvedSize = UIDevice.current.userInterfaceIdiom == .pad
+            ? (baseSize * 1.4).rounded()
+            : baseSize
+
+        let base = UIFont.systemFont(ofSize: resolvedSize, weight: weight ?? .regular)
+        return UIFontMetrics(forTextStyle: textStyle).scaledFont(for: base)
+    }
+}

--- a/WallaMarvel/Presentation/ListCharacter/DetailCharacter/DetailCharacterViewController.swift
+++ b/WallaMarvel/Presentation/ListCharacter/DetailCharacter/DetailCharacterViewController.swift
@@ -9,13 +9,10 @@ final class DetailCharacterViewController: UIViewController {
         static let stackSpacing: CGFloat = 16
         static let contentInset: CGFloat = 16
         static let contentVerticalInset: CGFloat = 24
-        static let imageSize: CGFloat = 200
-        static let imageCornerRadius: CGFloat = 100
-        static let badgeFontSize: CGFloat = 14
+        static let imageSize: CGFloat = UIDevice.current.userInterfaceIdiom == .pad ? 300 : 200
+        static var imageCornerRadius: CGFloat { imageSize / 2 }
         static let badgeCornerRadius: CGFloat = 10
         static let badgeHeight: CGFloat = 28
-        static let sectionFontSize: CGFloat = 17
-        static let rowFontSize: CGFloat = 15
         static let rowSpacing: CGFloat = 8
         static let imageFadeDuration: CGFloat = 0.2
     }
@@ -58,14 +55,14 @@ final class DetailCharacterViewController: UIViewController {
         let iv = UIImageView()
         iv.contentMode = .scaleAspectFill
         iv.clipsToBounds = true
-        iv.layer.cornerRadius = Constants.imageCornerRadius
         iv.translatesAutoresizingMaskIntoConstraints = false
         return iv
     }()
 
     private let statusBadge: UILabel = {
         let label = UILabel()
-        label.font = .systemFont(ofSize: Constants.badgeFontSize, weight: .semibold)
+        label.font = UIFont.adaptive(textStyle: .footnote, weight: .semibold)
+        label.adjustsFontForContentSizeCategory = true
         label.textColor = .white
         label.layer.cornerRadius = Constants.badgeCornerRadius
         label.layer.masksToBounds = true
@@ -77,7 +74,8 @@ final class DetailCharacterViewController: UIViewController {
     private let episodeSectionLabel: UILabel = {
         let label = UILabel()
         label.text = Strings.firstSeenIn
-        label.font = .systemFont(ofSize: Constants.sectionFontSize, weight: .semibold)
+        label.font = .adaptive(textStyle: .headline)
+        label.adjustsFontForContentSizeCategory = true
         return label
     }()
 
@@ -90,7 +88,8 @@ final class DetailCharacterViewController: UIViewController {
     private let episodeInfoLabel: UILabel = {
         let label = UILabel()
         label.numberOfLines = 0
-        label.font = .systemFont(ofSize: Constants.rowFontSize)
+        label.font = .adaptive(textStyle: .subheadline)
+        label.adjustsFontForContentSizeCategory = true
         label.isHidden = true
         return label
     }()
@@ -98,7 +97,8 @@ final class DetailCharacterViewController: UIViewController {
     private let episodeErrorLabel: UILabel = {
         let label = UILabel()
         label.numberOfLines = 0
-        label.font = .systemFont(ofSize: Constants.rowFontSize)
+        label.font = .adaptive(textStyle: .subheadline)
+        label.adjustsFontForContentSizeCategory = true
         label.textColor = .systemRed
         label.isHidden = true
         return label
@@ -176,6 +176,7 @@ final class DetailCharacterViewController: UIViewController {
             imageView.widthAnchor.constraint(equalToConstant: Constants.imageSize),
             imageView.heightAnchor.constraint(equalToConstant: Constants.imageSize)
         ])
+        imageView.layer.cornerRadius = Constants.imageCornerRadius
         contentStack.addArrangedSubview(container)
 
         imageView.isAccessibilityElement = false
@@ -240,13 +241,15 @@ final class DetailCharacterViewController: UIViewController {
 
         let titleLabel = UILabel()
         titleLabel.text = title
-        titleLabel.font = .systemFont(ofSize: Constants.rowFontSize, weight: .semibold)
+        titleLabel.font = UIFont.adaptive(textStyle: .subheadline, weight: .semibold)
+        titleLabel.adjustsFontForContentSizeCategory = true
         titleLabel.setContentHuggingPriority(.defaultHigh, for: .horizontal)
         titleLabel.isAccessibilityElement = false
 
         let valueLabel = UILabel()
         valueLabel.text = value
-        valueLabel.font = .systemFont(ofSize: Constants.rowFontSize)
+        valueLabel.font = .adaptive(textStyle: .subheadline)
+        valueLabel.adjustsFontForContentSizeCategory = true
         valueLabel.textAlignment = .right
         valueLabel.numberOfLines = 0
         valueLabel.isAccessibilityElement = false

--- a/WallaMarvel/Presentation/ListCharacter/ListCharactersTableView.swift
+++ b/WallaMarvel/Presentation/ListCharacter/ListCharactersTableView.swift
@@ -10,7 +10,6 @@ final class ListCharactersView: UIView {
         static let retryButtonWidth: CGFloat = 120
         static let retryButtonHeight: CGFloat = 44
         static let retryButtonCornerRadius: CGFloat = 8
-        static let fontSize: CGFloat = 16
         static let emptySearchIconSize: CGFloat = 60
         static let emptySearchSpacing: CGFloat = 16
         static let emptySearchHorizontalInset: CGFloat = 32
@@ -75,7 +74,8 @@ final class ListCharactersView: UIView {
         let label = UILabel()
         label.translatesAutoresizingMaskIntoConstraints = false
         label.text = Strings.emptySearchTitle
-        label.font = UIFont.systemFont(ofSize: 18, weight: .semibold)
+        label.font = UIFont.adaptive(textStyle: .headline)
+        label.adjustsFontForContentSizeCategory = true
         label.textAlignment = .center
         label.textColor = .label
         label.isAccessibilityElement = false
@@ -86,7 +86,8 @@ final class ListCharactersView: UIView {
         let label = UILabel()
         label.translatesAutoresizingMaskIntoConstraints = false
         label.text = Strings.emptySearchMessage
-        label.font = UIFont.systemFont(ofSize: 15)
+        label.font = UIFont.adaptive(textStyle: .subheadline)
+        label.adjustsFontForContentSizeCategory = true
         label.textAlignment = .center
         label.textColor = .secondaryLabel
         label.numberOfLines = 0
@@ -99,7 +100,8 @@ final class ListCharactersView: UIView {
         label.translatesAutoresizingMaskIntoConstraints = false
         label.numberOfLines = 0
         label.textAlignment = .center
-        label.font = UIFont.systemFont(ofSize: Constants.fontSize, weight: .regular)
+        label.font = UIFont.adaptive(textStyle: .body)
+        label.adjustsFontForContentSizeCategory = true
         label.textColor = .darkText
         return label
     }()
@@ -108,7 +110,8 @@ final class ListCharactersView: UIView {
         let button = UIButton(type: .system)
         button.translatesAutoresizingMaskIntoConstraints = false
         button.setTitle(Strings.retry, for: .normal)
-        button.titleLabel?.font = UIFont.systemFont(ofSize: Constants.fontSize, weight: .semibold)
+        button.titleLabel?.font = UIFont.adaptive(textStyle: .headline)
+        button.titleLabel?.adjustsFontForContentSizeCategory = true
         button.backgroundColor = .systemBlue
         button.setTitleColor(.white, for: .normal)
         button.layer.cornerRadius = Constants.retryButtonCornerRadius

--- a/WallaMarvel/Presentation/ListCharacter/ListCharactersTableViewCell.swift
+++ b/WallaMarvel/Presentation/ListCharacter/ListCharactersTableViewCell.swift
@@ -27,6 +27,8 @@ final class ListCharactersTableViewCell: UITableViewCell {
     private let characterName: UILabel = {
         let label = UILabel()
         label.numberOfLines = 0
+        label.font = .adaptive(textStyle: .body)
+        label.adjustsFontForContentSizeCategory = true
         label.translatesAutoresizingMaskIntoConstraints = false
         return label
     }()


### PR DESCRIPTION
## Summary

- Created `UIFont+Adaptive.swift` — a single extension replacing all scattered `UIFont.systemFont(ofSize:)` calls across the presentation layer
- On iPad, font point sizes are multiplied by `1.4` before scaling with `UIFontMetrics`, producing noticeably larger text
- `DetailCharacterViewController` character image promoted from `200pt` fixed to `300pt` on iPad / `200pt` on iPhone
- Dynamic Type continues to work on both devices

## Context

- All fonts rendered at the same base size on iPhone and iPad — `preferredFont(forTextStyle:)` does not differentiate between device classes
- The detail screen image was visually undersized relative to the available space on iPad
- The app was designed and tested primarily on iPhone; no adaptation for larger screens had been done

## Evidences

| List Screen | Details Screen | 
|--------|--------|
| <img width="300" alt="Screenshot 2026-04-04 at 14 43 14" src="https://github.com/user-attachments/assets/96cabe37-2da6-4107-b9e3-1e8e89f0ca90" /> | <img width="300" alt="Screenshot 2026-04-04 at 14 43 27" src="https://github.com/user-attachments/assets/ba2885ec-48f9-4d98-8bf4-7b55a72f6a9e" /> | 

## Changes

- **`Presentation/Extensions/UIFont+Adaptive.swift`** *(new file)*
  - `UIFont.adaptive(textStyle:weight:)` — resolves base size from `preferredFont(forTextStyle:)`, applies `1.4×` multiplier on iPad, wraps result with `UIFontMetrics.scaledFont(for:)` to preserve Dynamic Type
  - Added to `project.pbxproj`: PBXFileReference, PBXBuildFile, `Extensions` group under `Presentation`, Sources build phase
- **`ListCharactersTableViewCell.swift`**
  - `characterName` font replaced with `UIFont.adaptive(textStyle: .body)`
- **`ListCharactersTableView.swift`**
  - `emptySearchTitleLabel`: `UIFont.adaptive(textStyle: .headline)`
  - `emptySearchMessageLabel`: `UIFont.adaptive(textStyle: .subheadline)`
  - `errorLabel`: `UIFont.adaptive(textStyle: .body)`
  - `retryButton`: `UIFont.adaptive(textStyle: .headline)`
  - Removed unused `Constants.fontSize`
- **`DetailCharacterViewController.swift`**
  - `statusBadge`: `UIFont.adaptive(textStyle: .footnote, weight: .semibold)`
  - `episodeSectionLabel`: `UIFont.adaptive(textStyle: .headline)`
  - `episodeInfoLabel` / `episodeErrorLabel`: `UIFont.adaptive(textStyle: .subheadline)`
  - `makeInfoRow` title/value: `UIFont.adaptive(textStyle: .subheadline, weight: .semibold)` / `.subheadline`
  - `Constants.imageSize` promoted to computed value: `300pt` on iPad, `200pt` on iPhone
  - `Constants.imageCornerRadius` derived as `imageSize / 2` — always correct, no second value to maintain
  - `cornerRadius` assignment moved from property declaration to `addImageView()` to ensure resolved value is used at layout time
  - Removed unused constants `badgeFontSize`, `sectionFontSize`, `rowFontSize`

## Notes

- The `1.4` scale factor lives in a single place inside `UIFont+Adaptive.swift` — trivial to tune
- No `UIDevice` checks are scattered across view files; all device logic is contained in the extension
- `adjustsFontForContentSizeCategory = true` set on every label — Dynamic Type accessibility preference continues to override sizes correctly on both devices
- No business logic affected; no new unit tests required