### PR TITLE
CHANGE:[WP-17] Facelifting home screen

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,29 @@ The project was received with **Marvel API** integration via `URLSession`, using
 - `imageCornerRadius` derived automatically as `imageSize / 2` — always correct regardless of device
 - `cornerRadius` applied at layout time (`addImageView()`) instead of at property declaration, ensuring the correct value is used
 
+---
+
+### WP-17 — List Screen Facelift and ViewModel Separation
+
+**Visual redesign (`ListCharactersTableViewCell`, `ListCharactersTableView`):**
+- Dark card design: card background `#0B1120`, `cornerRadius = 12`, drop shadow (opacity 0.5, radius 6)
+- Table view background `#06080F` across the table and all state containers — slightly darker than the card for depth
+- Rectangular character image: `88×88pt`, `cornerRadius = 8` — no longer circular
+- Cell layout: name label (white, headline semibold) + status row (colored 8pt dot + text) + species label (light gray)
+- Cards inset `16pt` from screen edges, `4pt` vertical padding per cell → `8pt` gap between cards
+- `separatorStyle = .none`; `backgroundColor = .clear` on cell and `contentView`
+
+**ViewModel separation (`CharacterCellViewModel`, `ListCharactersPresenter`):**
+- Introduced `CharacterCellViewModel` — `name`, `species`, `imageURL: URL?`, `statusText: String`, `statusColor: UIColor`
+- Status mapping (`switch character.status.lowercased()`) moved from the cell to `private func map(_ character: Character)` in `ListCharactersPresenter` — the single place that owns this logic
+- `ListCharactersUI` protocol updated: `update(characters:)` and `appendCharacters(_:)` now receive `[CharacterCellViewModel]` instead of `[Character]`
+- `private var displayedCharacters: [Character]` tracks the currently visible list (full or filtered by search)
+- `func character(at index: Int) -> Character?` added to `ListCharactersPresenterProtocol` — navigation decoupled from the Adapter
+- `ListCharactersAdapter` updated to hold `[CharacterCellViewModel]`; ViewController navigation uses `presenter?.character(at:)` instead of direct adapter access
+
+**Tests:**
+- 12 new presenter tests: ViewModel mapping (`Alive`→green, `dead`→red, `unknown`→gray, fallback→gray, name+species pass-through) and `character(at:)` (valid index, out-of-bounds, before load, during search, after clear search, after pagination, appended mapping)
+
 ## Technical Decisions
 ### Local filter vs. API search
 The search bar filters characters already loaded in memory instead of making a new API request on each keystroke. Since the app already paginates and accumulates all characters in `allCharacters`, querying the network again would be wasteful and would add latency with no real benefit for the user.
@@ -198,6 +221,9 @@ When an error state appears, `.screenChanged` is posted instead of `.announcemen
 
 ### Adaptive image size via computed constant
 Rather than maintaining separate size values for iPhone and iPad, `DetailCharacterViewController` exposes `Constants.imageSize` as a computed property (`300pt` on iPad, `200pt` on iPhone`) and derives `imageCornerRadius` as `imageSize / 2`. The layout code is unchanged — the device decision is fully contained in the constant.
+
+### `CharacterCellViewModel` — Presenter-owned mapping, dumb View
+Status color and text resolution (`"alive" → .systemGreen / "Alive"`) belongs to the Presenter, not the View. The View has no branch logic — it only applies values. `CharacterCellViewModel` makes the boundary explicit: the Presenter maps Domain types to UI-ready values; the cell assigns them without decisions. This also keeps `UIColor` out of the Domain layer while keeping the mapping testable at the Presenter level.
 
 ## Test Coverage
 Patterns used:

--- a/WallaMarvel.xcodeproj/project.pbxproj
+++ b/WallaMarvel.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		AA9F1234567BCDEF12345678 /* UIFont+Adaptive.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB9F1234567BCDEF12345678 /* UIFont+Adaptive.swift */; };
+		DD9F1234567BCDEF12345678 /* CharacterCellViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE9F1234567BCDEF12345678 /* CharacterCellViewModel.swift */; };
 		0032C06B0B130FE8301D5B4B /* EpisodeDataSourceSpy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D17CFACB97F14547FDA15DA /* EpisodeDataSourceSpy.swift */; };
 		07B2C0EEDB0C6721A19AA357 /* EpisodeDataModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0291A77268CD1B64903B8E99 /* EpisodeDataModel.swift */; };
 		0D6A93A4DA0047F880E557F5 /* AppCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81E290EAA75A481AABB9C916 /* AppCoordinatorTests.swift */; };
@@ -132,6 +133,7 @@
 		1A3B7329286AE195007BF626 /* ListCharactersAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListCharactersAdapter.swift; sourceTree = "<group>"; };
 		1A7B9BBE286D81B600EBC1A6 /* Thumbnail.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Thumbnail.swift; sourceTree = "<group>"; };
 		BB9F1234567BCDEF12345678 /* UIFont+Adaptive.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "UIFont+Adaptive.swift"; sourceTree = "<group>"; };
+		EE9F1234567BCDEF12345678 /* CharacterCellViewModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CharacterCellViewModel.swift; sourceTree = "<group>"; };
 		1A8026D70B99D566B4C16C59 /* EpisodeRepository.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = EpisodeRepository.swift; sourceTree = "<group>"; };
 		1A821EC82862FE3C0024D397 /* APIClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIClient.swift; sourceTree = "<group>"; };
 		1A821ED3286302EC0024D397 /* CharacterResponseDataModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CharacterResponseDataModel.swift; sourceTree = "<group>"; };
@@ -299,6 +301,7 @@
 				1A3B7325286ADD1E007BF626 /* ListCharactersTableView.swift */,
 				1A3B7327286ADEE6007BF626 /* ListCharactersTableViewCell.swift */,
 				1A821ED92863096C0024D397 /* ListCharactersPresenter.swift */,
+				EE9F1234567BCDEF12345678 /* CharacterCellViewModel.swift */,
 			);
 			path = ListCharacter;
 			sourceTree = "<group>";
@@ -721,6 +724,7 @@
 				81C6CDB86EAFB60DE88A63DC /* GetEpisodeRequest.swift in Sources */,
 				565172C41918A3AF9B8FFF82 /* DetailCharacterPresenter.swift in Sources */,
 				AA9F1234567BCDEF12345678 /* UIFont+Adaptive.swift in Sources */,
+				DD9F1234567BCDEF12345678 /* CharacterCellViewModel.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/WallaMarvel/Presentation/ListCharacter/CharacterCellViewModel.swift
+++ b/WallaMarvel/Presentation/ListCharacter/CharacterCellViewModel.swift
@@ -1,0 +1,9 @@
+import UIKit
+
+struct CharacterCellViewModel {
+    let name: String
+    let species: String
+    let imageURL: URL?
+    let statusText: String
+    let statusColor: UIColor
+}

--- a/WallaMarvel/Presentation/ListCharacter/ListCharactersAdapter.swift
+++ b/WallaMarvel/Presentation/ListCharacter/ListCharactersAdapter.swift
@@ -2,7 +2,7 @@ import Foundation
 import UIKit
 
 final class ListCharactersAdapter: NSObject, UITableViewDataSource {
-    private(set) var characters: [Character] = []
+    private(set) var viewModels: [CharacterCellViewModel] = []
     private let tableView: UITableView
     private let paginationFooter: UIActivityIndicatorView = {
         let indicator = UIActivityIndicatorView(style: .medium)
@@ -10,22 +10,22 @@ final class ListCharactersAdapter: NSObject, UITableViewDataSource {
         return indicator
     }()
 
-    init(tableView: UITableView, characters: [Character] = []) {
+    init(tableView: UITableView, viewModels: [CharacterCellViewModel] = []) {
         self.tableView = tableView
-        self.characters = characters
+        self.viewModels = viewModels
         super.init()
         self.tableView.dataSource = self
     }
 
-    func setCharacters(_ newCharacters: [Character]) {
-        characters = newCharacters
+    func setCharacters(_ newViewModels: [CharacterCellViewModel]) {
+        viewModels = newViewModels
         tableView.reloadData()
     }
 
-    func appendCharacters(_ newCharacters: [Character]) {
-        let startIndex = characters.count
-        characters.append(contentsOf: newCharacters)
-        let indexPaths = (startIndex..<characters.count).map { IndexPath(row: $0, section: 0) }
+    func appendCharacters(_ newViewModels: [CharacterCellViewModel]) {
+        let startIndex = viewModels.count
+        viewModels.append(contentsOf: newViewModels)
+        let indexPaths = (startIndex..<viewModels.count).map { IndexPath(row: $0, section: 0) }
         tableView.insertRows(at: indexPaths, with: .automatic)
     }
 
@@ -40,12 +40,12 @@ final class ListCharactersAdapter: NSObject, UITableViewDataSource {
     }
 
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        characters.count
+        viewModels.count
     }
 
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell = tableView.dequeueReusableCell(withIdentifier: "ListCharactersTableViewCell", for: indexPath) as! ListCharactersTableViewCell
-        cell.configure(model: characters[indexPath.row])
+        cell.configure(viewModel: viewModels[indexPath.row])
         return cell
     }
 }

--- a/WallaMarvel/Presentation/ListCharacter/ListCharactersPresenter.swift
+++ b/WallaMarvel/Presentation/ListCharacter/ListCharactersPresenter.swift
@@ -1,4 +1,5 @@
 import Foundation
+import UIKit
 
 @MainActor
 protocol ListCharactersPresenterProtocol: AnyObject {
@@ -9,14 +10,15 @@ protocol ListCharactersPresenterProtocol: AnyObject {
     func retryNextPage() async
     func searchCharacters(name: String)
     func clearSearch()
+    func character(at index: Int) -> Character?
 }
 
 @MainActor
 protocol ListCharactersUI: AnyObject {
     func showLoading()
     func hideLoading()
-    func update(characters: [Character])
-    func appendCharacters(_ newCharacters: [Character])
+    func update(characters: [CharacterCellViewModel])
+    func appendCharacters(_ newCharacters: [CharacterCellViewModel])
     func showPaginationLoading()
     func hidePaginationLoading()
     func showError(_ error: AppError)
@@ -38,6 +40,7 @@ final class ListCharactersPresenter: ListCharactersPresenterProtocol {
     private var isLoadingPage = false
     private var isPaginationBlocked = false
     private var allCharacters: [Character] = []
+    private var displayedCharacters: [Character] = []
     private var isSearchActive = false
 
     init(getCharactersUseCase: GetCharactersUseCaseProtocol) {
@@ -48,6 +51,11 @@ final class ListCharactersPresenter: ListCharactersPresenterProtocol {
         Strings.screenTitle
     }
 
+    func character(at index: Int) -> Character? {
+        guard index < displayedCharacters.count else { return nil }
+        return displayedCharacters[index]
+    }
+
     func getCharacters() async {
         ui?.showLoading()
         currentPage = 1
@@ -56,13 +64,15 @@ final class ListCharactersPresenter: ListCharactersPresenterProtocol {
         isPaginationBlocked = false
         isSearchActive = false
         allCharacters = []
+        displayedCharacters = []
 
         do {
             let page = try await getCharactersUseCase.execute(page: currentPage)
             hasNextPage = page.hasNextPage
             allCharacters = page.characters
+            displayedCharacters = allCharacters
             ui?.hideLoading()
-            ui?.update(characters: allCharacters)
+            ui?.update(characters: map(allCharacters))
         } catch let error as AppError {
             ui?.hideLoading()
             ui?.showError(error)
@@ -83,7 +93,8 @@ final class ListCharactersPresenter: ListCharactersPresenterProtocol {
             currentPage += 1
             hasNextPage = page.hasNextPage
             allCharacters.append(contentsOf: page.characters)
-            ui?.appendCharacters(page.characters)
+            displayedCharacters = allCharacters
+            ui?.appendCharacters(map(page.characters))
         } catch let error as AppError {
             isPaginationBlocked = true
             ui?.showPaginationError(error)
@@ -111,15 +122,40 @@ final class ListCharactersPresenter: ListCharactersPresenterProtocol {
         let filtered = allCharacters.filter {
             $0.name.localizedCaseInsensitiveContains(query)
         }
+        displayedCharacters = filtered
         if filtered.isEmpty {
             ui?.showEmptySearch()
         } else {
-            ui?.update(characters: filtered)
+            ui?.update(characters: map(filtered))
         }
     }
 
     func clearSearch() {
         isSearchActive = false
-        ui?.update(characters: allCharacters)
+        displayedCharacters = allCharacters
+        ui?.update(characters: map(allCharacters))
+    }
+
+    // MARK: - Private
+
+    private func map(_ characters: [Character]) -> [CharacterCellViewModel] {
+        characters.map { map($0) }
+    }
+
+    private func map(_ character: Character) -> CharacterCellViewModel {
+        let (statusText, statusColor): (String, UIColor) = {
+            switch character.status.lowercased() {
+            case "alive": return ("Alive", .systemGreen)
+            case "dead":  return ("Dead", .systemRed)
+            default:      return ("Unknown", .systemGray)
+            }
+        }()
+        return CharacterCellViewModel(
+            name: character.name,
+            species: character.species,
+            imageURL: URL(string: character.imageURL),
+            statusText: statusText,
+            statusColor: statusColor
+        )
     }
 }

--- a/WallaMarvel/Presentation/ListCharacter/ListCharactersTableView.swift
+++ b/WallaMarvel/Presentation/ListCharacter/ListCharactersTableView.swift
@@ -20,6 +20,10 @@ final class ListCharactersView: UIView {
         static let emptySearchTitle = "No characters found"
         static let emptySearchMessage = "Try a different name."
     }
+
+    private enum Colors {
+        static let background = UIColor(red: 6/255.0, green: 8/255.0, blue: 15/255.0, alpha: 1)
+    }
     
     private let charactersTableView: UITableView = {
         let tableView = UITableView()
@@ -27,19 +31,22 @@ final class ListCharactersView: UIView {
         tableView.translatesAutoresizingMaskIntoConstraints = false
         tableView.rowHeight = UITableView.automaticDimension
         tableView.estimatedRowHeight = Constants.estimatedRowHeight
+        tableView.separatorStyle = .none
+        tableView.backgroundColor = Colors.background
         return tableView
     }()
     
     private let loadingView: UIView = {
         let view = UIView()
         view.translatesAutoresizingMaskIntoConstraints = false
-        view.backgroundColor = .systemBackground
+        view.backgroundColor = Colors.background
         return view
     }()
     
     private let loadingIndicator: UIActivityIndicatorView = {
         let indicator = UIActivityIndicatorView(style: .large)
         indicator.translatesAutoresizingMaskIntoConstraints = false
+        indicator.color = .white
         indicator.startAnimating()
         return indicator
     }()
@@ -47,7 +54,7 @@ final class ListCharactersView: UIView {
     private let errorContainerView: UIView = {
         let view = UIView()
         view.translatesAutoresizingMaskIntoConstraints = false
-        view.backgroundColor = .systemBackground
+        view.backgroundColor = Colors.background
         view.isHidden = true
         return view
     }()
@@ -55,7 +62,7 @@ final class ListCharactersView: UIView {
     private let emptySearchContainerView: UIView = {
         let view = UIView()
         view.translatesAutoresizingMaskIntoConstraints = false
-        view.backgroundColor = .systemBackground
+        view.backgroundColor = Colors.background
         view.isHidden = true
         view.accessibilityElements = []
         return view
@@ -64,7 +71,7 @@ final class ListCharactersView: UIView {
     private let emptySearchIconView: UIImageView = {
         let image = UIImageView(image: UIImage(systemName: "magnifyingglass"))
         image.translatesAutoresizingMaskIntoConstraints = false
-        image.tintColor = .secondaryLabel
+        image.tintColor = .lightGray
         image.contentMode = .scaleAspectFit
         image.isAccessibilityElement = false
         return image
@@ -77,7 +84,7 @@ final class ListCharactersView: UIView {
         label.font = UIFont.adaptive(textStyle: .headline)
         label.adjustsFontForContentSizeCategory = true
         label.textAlignment = .center
-        label.textColor = .label
+        label.textColor = .white
         label.isAccessibilityElement = false
         return label
     }()
@@ -89,7 +96,7 @@ final class ListCharactersView: UIView {
         label.font = UIFont.adaptive(textStyle: .subheadline)
         label.adjustsFontForContentSizeCategory = true
         label.textAlignment = .center
-        label.textColor = .secondaryLabel
+        label.textColor = .lightGray
         label.numberOfLines = 0
         label.isAccessibilityElement = false
         return label
@@ -102,7 +109,7 @@ final class ListCharactersView: UIView {
         label.textAlignment = .center
         label.font = UIFont.adaptive(textStyle: .body)
         label.adjustsFontForContentSizeCategory = true
-        label.textColor = .darkText
+        label.textColor = .white
         return label
     }()
     
@@ -129,6 +136,7 @@ final class ListCharactersView: UIView {
     }
     
     private func setup() {
+        backgroundColor = Colors.background
         addSubviews()
         addContraints()
     }

--- a/WallaMarvel/Presentation/ListCharacter/ListCharactersTableViewCell.swift
+++ b/WallaMarvel/Presentation/ListCharacter/ListCharactersTableViewCell.swift
@@ -3,48 +3,124 @@ import UIKit
 import Kingfisher
 
 final class ListCharactersTableViewCell: UITableViewCell {
+
     private enum Constants {
-        static let imageSize: CGFloat = 80
-        static let imageCornerRadius: CGFloat = 40
-        static let outerSpacing: CGFloat = 12
-        static let innerSpacing: CGFloat = 8
+        static let cardCornerRadius: CGFloat = 12
+        static let cardHorizontalInset: CGFloat = 16
+        static let cardVerticalInset: CGFloat = 4
+        static let contentPadding: CGFloat = 12
+        static let imageSize: CGFloat = 88
+        static let imageCornerRadius: CGFloat = 8
+        static let innerSpacing: CGFloat = 6
+        static let statusDotSize: CGFloat = 8
+        static let shadowRadius: CGFloat = 6
+        static let shadowOpacity: Float = 0.5
     }
 
     private enum Strings {
-        static let placeholderImage = "person.crop.circle.fill"
+        static let placeholderImage = "person.crop.rectangle.fill"
         static let accessibilityHint = "Double tap to see more details"
     }
+
+    // MARK: - Card
+
+    private let cardView: UIView = {
+        let view = UIView()
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.backgroundColor = UIColor(red: 11/255.0, green: 17/255.0, blue: 32/255.0, alpha: 1)
+        view.layer.cornerRadius = Constants.cardCornerRadius
+        view.layer.shadowColor = UIColor.black.cgColor
+        view.layer.shadowOffset = CGSize(width: 0, height: 2)
+        view.layer.shadowRadius = Constants.shadowRadius
+        view.layer.shadowOpacity = Constants.shadowOpacity
+        return view
+    }()
+
+    // MARK: - Image
+
     private let characterImageView: UIImageView = {
         let imageView = UIImageView()
         imageView.translatesAutoresizingMaskIntoConstraints = false
         imageView.contentMode = .scaleAspectFill
         imageView.clipsToBounds = true
-        imageView.tintColor = .systemGray3
+        imageView.tintColor = .systemGray
         imageView.layer.cornerRadius = Constants.imageCornerRadius
+        imageView.backgroundColor = UIColor(white: 1, alpha: 0.05)
         return imageView
     }()
-    
-    private let characterName: UILabel = {
+
+    // MARK: - Labels
+
+    private let nameLabel: UILabel = {
         let label = UILabel()
-        label.numberOfLines = 0
-        label.font = .adaptive(textStyle: .body)
+        label.numberOfLines = 2
+        label.font = .adaptive(textStyle: .headline, weight: .semibold)
         label.adjustsFontForContentSizeCategory = true
-        label.translatesAutoresizingMaskIntoConstraints = false
+        label.textColor = .white
         return label
     }()
-    
+
+    private let statusDot: UIView = {
+        let view = UIView()
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.layer.cornerRadius = Constants.statusDotSize / 2
+        return view
+    }()
+
+    private let statusLabel: UILabel = {
+        let label = UILabel()
+        label.font = .adaptive(textStyle: .subheadline)
+        label.adjustsFontForContentSizeCategory = true
+        label.textColor = UIColor.white.withAlphaComponent(0.75)
+        return label
+    }()
+
+    private let speciesLabel: UILabel = {
+        let label = UILabel()
+        label.font = .adaptive(textStyle: .subheadline)
+        label.adjustsFontForContentSizeCategory = true
+        label.textColor = .lightGray
+        return label
+    }()
+
+    // MARK: - Stacks
+
+    private lazy var statusRow: UIStackView = {
+        let stack = UIStackView(arrangedSubviews: [statusDot, statusLabel])
+        stack.axis = .horizontal
+        stack.spacing = Constants.innerSpacing
+        stack.alignment = .center
+        return stack
+    }()
+
+    private lazy var infoStack: UIStackView = {
+        let stack = UIStackView(arrangedSubviews: [nameLabel, statusRow, speciesLabel])
+        stack.axis = .vertical
+        stack.spacing = Constants.innerSpacing
+        stack.alignment = .leading
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        return stack
+    }()
+
+    // MARK: - Init
+
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
         setup()
     }
-    
+
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-    
+
+    // MARK: - Setup
+
     private func setup() {
+        backgroundColor = .clear
+        contentView.backgroundColor = .clear
+        selectionStyle = .none
         addSubviews()
-        addContraints()
+        addConstraints()
         setupAccessibility()
     }
 
@@ -52,33 +128,51 @@ final class ListCharactersTableViewCell: UITableViewCell {
         isAccessibilityElement = true
         accessibilityHint = Strings.accessibilityHint
         characterImageView.isAccessibilityElement = false
-        characterName.isAccessibilityElement = false
+        nameLabel.isAccessibilityElement = false
+        statusLabel.isAccessibilityElement = false
+        speciesLabel.isAccessibilityElement = false
     }
-    
+
     private func addSubviews() {
-        addSubview(characterImageView)
-        addSubview(characterName)
+        contentView.addSubview(cardView)
+        cardView.addSubview(characterImageView)
+        cardView.addSubview(infoStack)
     }
-    
-    private func addContraints() {
+
+    private func addConstraints() {
         NSLayoutConstraint.activate([
-            characterImageView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: Constants.outerSpacing),
-            characterImageView.topAnchor.constraint(equalTo: topAnchor, constant: Constants.outerSpacing),
-            characterImageView.heightAnchor.constraint(equalToConstant: Constants.imageSize),
+            cardView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: Constants.cardHorizontalInset),
+            cardView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -Constants.cardHorizontalInset),
+            cardView.topAnchor.constraint(equalTo: contentView.topAnchor, constant: Constants.cardVerticalInset),
+            cardView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -Constants.cardVerticalInset),
+
+            characterImageView.leadingAnchor.constraint(equalTo: cardView.leadingAnchor, constant: Constants.contentPadding),
+            characterImageView.topAnchor.constraint(equalTo: cardView.topAnchor, constant: Constants.contentPadding),
+            characterImageView.bottomAnchor.constraint(equalTo: cardView.bottomAnchor, constant: -Constants.contentPadding),
             characterImageView.widthAnchor.constraint(equalToConstant: Constants.imageSize),
-            characterImageView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -Constants.outerSpacing),
-            
-            characterName.leadingAnchor.constraint(equalTo: characterImageView.trailingAnchor, constant: Constants.outerSpacing),
-            characterName.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -Constants.outerSpacing),
-            characterName.topAnchor.constraint(equalTo: characterImageView.topAnchor, constant: Constants.innerSpacing),
-            characterName.centerYAnchor.constraint(equalTo: characterImageView.centerYAnchor),
+            characterImageView.heightAnchor.constraint(equalToConstant: Constants.imageSize),
+
+            statusDot.widthAnchor.constraint(equalToConstant: Constants.statusDotSize),
+            statusDot.heightAnchor.constraint(equalToConstant: Constants.statusDotSize),
+
+            infoStack.leadingAnchor.constraint(equalTo: characterImageView.trailingAnchor, constant: Constants.contentPadding),
+            infoStack.trailingAnchor.constraint(equalTo: cardView.trailingAnchor, constant: -Constants.contentPadding),
+            infoStack.centerYAnchor.constraint(equalTo: characterImageView.centerYAnchor),
+            infoStack.topAnchor.constraint(greaterThanOrEqualTo: cardView.topAnchor, constant: Constants.contentPadding),
+            infoStack.bottomAnchor.constraint(lessThanOrEqualTo: cardView.bottomAnchor, constant: -Constants.contentPadding),
         ])
     }
-    
-    func configure(model: Character) {
+
+    // MARK: - Configure
+
+    func configure(viewModel: CharacterCellViewModel) {
         let placeholder = UIImage(systemName: Strings.placeholderImage)
-        characterImageView.kf.setImage(with: URL(string: model.imageURL), placeholder: placeholder)
-        characterName.text = model.name
-        accessibilityLabel = "Character: \(model.name)."
+        characterImageView.kf.setImage(with: viewModel.imageURL, placeholder: placeholder)
+        nameLabel.text = viewModel.name
+        speciesLabel.text = viewModel.species
+        statusDot.backgroundColor = viewModel.statusColor
+        statusLabel.text = viewModel.statusText
+        accessibilityLabel = "Character: \(viewModel.name). Status: \(viewModel.statusText). \(viewModel.species)."
     }
 }
+

--- a/WallaMarvel/Presentation/ListCharacter/ListCharactersViewController.swift
+++ b/WallaMarvel/Presentation/ListCharacter/ListCharactersViewController.swift
@@ -64,12 +64,12 @@ extension ListCharactersViewController: ListCharactersUI {
         mainView.hideLoading()
     }
 
-    func update(characters: [Character]) {
+    func update(characters: [CharacterCellViewModel]) {
         mainView.showCharacters()
         listCharactersProvider?.setCharacters(characters)
     }
 
-    func appendCharacters(_ newCharacters: [Character]) {
+    func appendCharacters(_ newCharacters: [CharacterCellViewModel]) {
         listCharactersProvider?.appendCharacters(newCharacters)
     }
 
@@ -115,7 +115,7 @@ extension ListCharactersViewController: ListCharactersUI {
 
 extension ListCharactersViewController: UITableViewDelegate {
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        guard let character = listCharactersProvider?.characters[indexPath.row] else { return }
+        guard let character = presenter?.character(at: indexPath.row) else { return }
         coordinator?.showDetail(for: character)
     }
 

--- a/WallaMarvelTests/Presentation/ListCharactersPresenterTests.swift
+++ b/WallaMarvelTests/Presentation/ListCharactersPresenterTests.swift
@@ -332,4 +332,163 @@ final class ListCharactersPresenterTests: XCTestCase {
 
         XCTAssertFalse(getCharactersUseCaseSpy.executeCalled)
     }
+
+    // MARK: - ViewModel mapping
+
+    func test_whenGetCharacters_withAliveStatus_shouldMapStatusTextAndColorCorrectly() async {
+        getCharactersUseCaseSpy.pageResult = CharactersPage(
+            characters: [.fixture(status: "Alive")],
+            hasNextPage: false
+        )
+        let uiSpy = ListCharactersUISpy()
+        sut.ui = uiSpy
+
+        await sut.getCharacters()
+
+        XCTAssertEqual(uiSpy.updatedCharacters.first?.statusText, "Alive")
+        XCTAssertEqual(uiSpy.updatedCharacters.first?.statusColor, .systemGreen)
+    }
+
+    func test_whenGetCharacters_withDeadStatus_shouldMapStatusTextAndColorCorrectly() async {
+        getCharactersUseCaseSpy.pageResult = CharactersPage(
+            characters: [.fixture(status: "dead")],
+            hasNextPage: false
+        )
+        let uiSpy = ListCharactersUISpy()
+        sut.ui = uiSpy
+
+        await sut.getCharacters()
+
+        XCTAssertEqual(uiSpy.updatedCharacters.first?.statusText, "Dead")
+        XCTAssertEqual(uiSpy.updatedCharacters.first?.statusColor, .systemRed)
+    }
+
+    func test_whenGetCharacters_withUnknownStatus_shouldMapStatusTextAndColorCorrectly() async {
+        getCharactersUseCaseSpy.pageResult = CharactersPage(
+            characters: [.fixture(status: "unknown")],
+            hasNextPage: false
+        )
+        let uiSpy = ListCharactersUISpy()
+        sut.ui = uiSpy
+
+        await sut.getCharacters()
+
+        XCTAssertEqual(uiSpy.updatedCharacters.first?.statusText, "Unknown")
+        XCTAssertEqual(uiSpy.updatedCharacters.first?.statusColor, .systemGray)
+    }
+
+    func test_whenGetCharacters_withArbitraryStatus_shouldFallbackToUnknown() async {
+        getCharactersUseCaseSpy.pageResult = CharactersPage(
+            characters: [.fixture(status: "Zombie")],
+            hasNextPage: false
+        )
+        let uiSpy = ListCharactersUISpy()
+        sut.ui = uiSpy
+
+        await sut.getCharacters()
+
+        XCTAssertEqual(uiSpy.updatedCharacters.first?.statusText, "Unknown")
+        XCTAssertEqual(uiSpy.updatedCharacters.first?.statusColor, .systemGray)
+    }
+
+    func test_whenGetCharacters_succeeds_shouldMapNameAndSpeciesCorrectly() async {
+        getCharactersUseCaseSpy.pageResult = CharactersPage(
+            characters: [.fixture(name: "Morty Smith", species: "Human")],
+            hasNextPage: false
+        )
+        let uiSpy = ListCharactersUISpy()
+        sut.ui = uiSpy
+
+        await sut.getCharacters()
+
+        XCTAssertEqual(uiSpy.updatedCharacters.first?.name, "Morty Smith")
+        XCTAssertEqual(uiSpy.updatedCharacters.first?.species, "Human")
+    }
+
+    // MARK: - character(at:)
+
+    func test_whenCharacterAt_withValidIndex_shouldReturnCorrectCharacter() async {
+        let morty = Character.fixture(id: 1, name: "Morty Smith")
+        let rick = Character.fixture(id: 2, name: "Rick Sanchez")
+        getCharactersUseCaseSpy.pageResult = CharactersPage(characters: [morty, rick], hasNextPage: false)
+        sut.ui = ListCharactersUISpy()
+
+        await sut.getCharacters()
+
+        XCTAssertEqual(sut.character(at: 0)?.name, "Morty Smith")
+        XCTAssertEqual(sut.character(at: 1)?.name, "Rick Sanchez")
+    }
+
+    func test_whenCharacterAt_withOutOfBoundsIndex_shouldReturnNil() async {
+        getCharactersUseCaseSpy.pageResult = CharactersPage(characters: [.fixture()], hasNextPage: false)
+        sut.ui = ListCharactersUISpy()
+
+        await sut.getCharacters()
+
+        XCTAssertNil(sut.character(at: 99))
+    }
+
+    func test_whenCharacterAt_duringActiveSearch_shouldReturnFromFilteredList() async {
+        let morty = Character.fixture(id: 1, name: "Morty Smith")
+        let rick = Character.fixture(id: 2, name: "Rick Sanchez")
+        getCharactersUseCaseSpy.pageResult = CharactersPage(characters: [morty, rick], hasNextPage: false)
+        sut.ui = ListCharactersUISpy()
+
+        await sut.getCharacters()
+        sut.searchCharacters(name: "Rick")
+
+        XCTAssertEqual(sut.character(at: 0)?.name, "Rick Sanchez")
+        XCTAssertNil(sut.character(at: 1))
+    }
+
+    func test_whenCharacterAt_afterClearSearch_shouldReturnFromFullList() async {
+        let morty = Character.fixture(id: 1, name: "Morty Smith")
+        let rick = Character.fixture(id: 2, name: "Rick Sanchez")
+        getCharactersUseCaseSpy.pageResult = CharactersPage(characters: [morty, rick], hasNextPage: false)
+        sut.ui = ListCharactersUISpy()
+
+        await sut.getCharacters()
+        sut.searchCharacters(name: "Rick")
+        sut.clearSearch()
+
+        XCTAssertEqual(sut.character(at: 0)?.name, "Morty Smith")
+        XCTAssertEqual(sut.character(at: 1)?.name, "Rick Sanchez")
+    }
+
+    func test_whenCharacterAt_beforeGetCharacters_shouldReturnNil() {
+        XCTAssertNil(sut.character(at: 0))
+    }
+
+    func test_whenCharacterAt_afterLoadNextPage_shouldReturnCharactersAcrossPages() async {
+        let firstPage = [Character.fixture(id: 1, name: "Morty Smith")]
+        let secondPage = [Character.fixture(id: 2, name: "Rick Sanchez")]
+        getCharactersUseCaseSpy.pageResult = CharactersPage(characters: firstPage, hasNextPage: true)
+        let uiSpy = ListCharactersUISpy()
+        sut.ui = uiSpy
+
+        await sut.getCharacters()
+
+        getCharactersUseCaseSpy.pageResult = CharactersPage(characters: secondPage, hasNextPage: false)
+        await sut.loadNextPage()
+
+        XCTAssertEqual(sut.character(at: 0)?.name, "Morty Smith")
+        XCTAssertEqual(sut.character(at: 1)?.name, "Rick Sanchez")
+    }
+
+    func test_whenLoadNextPage_succeeds_shouldMapAppendedCharactersCorrectly() async {
+        getCharactersUseCaseSpy.pageResult = CharactersPage(characters: [.fixture()], hasNextPage: true)
+        let uiSpy = ListCharactersUISpy()
+        sut.ui = uiSpy
+
+        await sut.getCharacters()
+
+        getCharactersUseCaseSpy.pageResult = CharactersPage(
+            characters: [.fixture(id: 2, status: "dead")],
+            hasNextPage: false
+        )
+        await sut.loadNextPage()
+
+        XCTAssertEqual(uiSpy.appendedCharacters.first?.statusText, "Dead")
+        XCTAssertEqual(uiSpy.appendedCharacters.first?.statusColor, .systemRed)
+    }
 }

--- a/WallaMarvelTests/Spies/ListCharactersPresenterSpy.swift
+++ b/WallaMarvelTests/Spies/ListCharactersPresenterSpy.swift
@@ -10,6 +10,9 @@ final class ListCharactersPresenterSpy: ListCharactersPresenterProtocol {
     private(set) var lastSearchedName: String?
     private(set) var clearSearchCalled = false
 
+    private(set) var characterAtIndexCalled = false
+    private(set) var lastRequestedIndex: Int?
+
     func screenTitle() -> String {
         screenTitleCalled = true
         return "Characters"
@@ -34,5 +37,11 @@ final class ListCharactersPresenterSpy: ListCharactersPresenterProtocol {
 
     func clearSearch() {
         clearSearchCalled = true
+    }
+
+    func character(at index: Int) -> Character? {
+        characterAtIndexCalled = true
+        lastRequestedIndex = index
+        return nil
     }
 }

--- a/WallaMarvelTests/Spies/ListCharactersUISpy.swift
+++ b/WallaMarvelTests/Spies/ListCharactersUISpy.swift
@@ -3,8 +3,8 @@ import XCTest
 
 final class ListCharactersUISpy: ListCharactersUI {
     private(set) var updatedCharactersCount: Int?
-    private(set) var updatedCharacters: [Character] = []
-    private(set) var appendedCharacters: [Character] = []
+    private(set) var updatedCharacters: [CharacterCellViewModel] = []
+    private(set) var appendedCharacters: [CharacterCellViewModel] = []
     private(set) var lastShownError: AppError?
     private(set) var lastPaginationError: AppError?
     private(set) var isLoadingShown: Bool = false
@@ -29,13 +29,13 @@ final class ListCharactersUISpy: ListCharactersUI {
         hideLoadingWasCalled = true
     }
 
-    func update(characters: [Character]) {
+    func update(characters: [CharacterCellViewModel]) {
         updatedCharacters = characters
         updatedCharactersCount = characters.count
         updateExpectation?.fulfill()
     }
 
-    func appendCharacters(_ newCharacters: [Character]) {
+    func appendCharacters(_ newCharacters: [CharacterCellViewModel]) {
         appendedCharacters.append(contentsOf: newCharacters)
     }
 


### PR DESCRIPTION
## Summary

- Redesigned the character list cell with a dark card style matching the splash screen color palette
- Introduced `CharacterCellViewModel` to move status mapping logic out of the View layer and into the Presenter
- Added `character(at:)` to `ListCharactersPresenterProtocol` to decouple navigation from the Adapter
- Added 12 new unit tests covering ViewModel mapping and `character(at:)` behavior

## Context

- The list screen had no visual identity — plain white cells with no styling cues
- Status color/text logic (`switch status.lowercased()`) was living inside the cell, violating the principle that Views should be dumb
- Navigation on tap relied on `listCharactersProvider?.characters[indexPath.row]`, exposing internal adapter state directly to the ViewController

| Before | After |
|---|---|
| <img width="200" alt="Simulator Screenshot - iPhone 17 Pro - 2026-04-04 at 15 14 19" src="https://github.com/user-attachments/assets/50278c8c-2b3c-4b72-9651-00dcb862002b" /> | <img width="200" alt="Simulator Screenshot - iPhone 17 Pro - 2026-04-04 at 15 29 21" src="https://github.com/user-attachments/assets/235fa683-d7a2-40df-bf07-564261a8af36" />  |

## Changes

- **`ListCharactersTableViewCell.swift`** — full rewrite:
  - `cardView` with background `#0B1120`, `cornerRadius = 12`, drop shadow
  - Rectangular image (`88×88pt`, `cornerRadius = 8`) — no longer circular
  - `nameLabel` (white, `.headline semibold`), `statusRow` (colored dot `8pt` + status text), `speciesLabel` (`.lightGray`, `.subheadline`)
  - Card inset: `16pt` from screen edges, `4pt` top/bottom → `8pt` between cards
  - `backgroundColor = .clear` on cell and `contentView`; `selectionStyle = .none`
  - `configure(viewModel: CharacterCellViewModel)` — no logic, only value assignment
- **`ListCharactersTableView.swift`**:
  - `Colors.background = #06080F` applied to view, table view, loading, error and empty search containers
  - `separatorStyle = .none`
  - `loadingIndicator.color = .white`
  - Empty state and error labels updated to white/lightGray
- **`CharacterCellViewModel.swift`** *(new file)*:
  - `name`, `species`, `imageURL: URL?`, `statusText: String`, `statusColor: UIColor`
  - Added to `project.pbxproj`
- **`ListCharactersPresenter.swift`**:
  - `update(characters:)` and `appendCharacters(_:)` in `ListCharactersUI` protocol updated to `[CharacterCellViewModel]`
  - `private func map(_ character: Character) -> CharacterCellViewModel` — single place owning the status switch
  - `private var displayedCharacters: [Character]` tracks the currently visible list (full or filtered)
  - `func character(at index: Int) -> Character?` added to protocol and implementation
  - `import UIKit` added (required for `UIColor` in mapping)
- **`ListCharactersAdapter.swift`**:
  - `characters: [Character]` replaced with `viewModels: [CharacterCellViewModel]`
  - `cell.configure(model:)` replaced with `cell.configure(viewModel:)`
- **`ListCharactersViewController.swift`**:
  - `update` and `appendCharacters` conformance updated to `[CharacterCellViewModel]`
  - `didSelectRowAt` now calls `presenter?.character(at: indexPath.row)` instead of accessing the adapter directly
- **`ListCharactersUISpy.swift`** — `updatedCharacters` and `appendedCharacters` updated to `[CharacterCellViewModel]`
- **`ListCharactersPresenterSpy.swift`** — `character(at:)` stub added
- **`ListCharactersPresenterTests.swift`** — 12 new tests:
  - ViewModel mapping: `Alive`, `Dead`, `Unknown`, arbitrary fallback, `name`/`species`
  - `character(at:)`: valid index, out-of-bounds, during search, after clear search, before load, after pagination
  - Appended characters mapping: `statusText`/`statusColor` validated on page 2 results

## Notes

- `UIColor` values in `CharacterCellViewModel` are a deliberate Presentation-layer concern — the Presenter maps domain strings to platform colors; the View only applies them
- The `displayedCharacters` array keeps `character(at:)` consistent with what the user sees, including during active search — navigation always goes to the correct character
- No Domain or Data layer changes