### PR TITLE
REFACTOR:[WP-19] Apply ViewCode protocol and move constraints to extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,6 +247,9 @@ The detail screen hero image height is defined as a single `Constants.imageHeigh
 ### `CharacterCellViewModel` — Presenter-owned mapping, dumb View
 Status color and text resolution (`"alive" → .systemGreen / "Alive"`) belongs to the Presenter, not the View. The View has no branch logic — it only applies values. `CharacterCellViewModel` makes the boundary explicit: the Presenter maps Domain types to UI-ready values; the cell assigns them without decisions. This also keeps `UIColor` out of the Domain layer while keeping the mapping testable at the Presenter level.
 
+### `ViewCode` protocol — uniform layout structure across all views
+All `UIView` subclasses in the Presentation layer conform to `ViewCode`, a lightweight protocol that enforces a consistent three-step setup sequence: `setupComponent()` (add subviews to the hierarchy), `setupConstrain()` (activate Auto Layout constraints), `setupExtraConfiguration()` (background colors, accessibility properties, `selectionStyle`, etc.). The default `setup()` implementation in the protocol extension calls the three steps in the correct order, so conforming types never call them out of order or forget a step. The impact is structural: any developer opening `ListCharactersView` or `ListCharactersTableViewCell` immediately knows where to find subview additions, where to find constraint activation, and where to find visual configuration — without reading the whole file.
+
 ## Test Coverage
 Patterns used:
 - **Spy** — verifies behavior (calls, parameters)

--- a/WallaMarvel.xcodeproj/project.pbxproj
+++ b/WallaMarvel.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		AA9F1234567BCDEF12345678 /* UIFont+Adaptive.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB9F1234567BCDEF12345678 /* UIFont+Adaptive.swift */; };
+		FF9F1234567BCDEF12345678 /* ViewCode.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE9F1234567BCDEF12345678 /* ViewCode.swift */; };
 		DD9F1234567BCDEF12345678 /* CharacterCellViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE9F1234567BCDEF12345678 /* CharacterCellViewModel.swift */; };
 		0032C06B0B130FE8301D5B4B /* EpisodeDataSourceSpy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D17CFACB97F14547FDA15DA /* EpisodeDataSourceSpy.swift */; };
 		07B2C0EEDB0C6721A19AA357 /* EpisodeDataModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0291A77268CD1B64903B8E99 /* EpisodeDataModel.swift */; };
@@ -133,6 +134,7 @@
 		1A3B7329286AE195007BF626 /* ListCharactersAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListCharactersAdapter.swift; sourceTree = "<group>"; };
 		1A7B9BBE286D81B600EBC1A6 /* Thumbnail.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Thumbnail.swift; sourceTree = "<group>"; };
 		BB9F1234567BCDEF12345678 /* UIFont+Adaptive.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "UIFont+Adaptive.swift"; sourceTree = "<group>"; };
+		FE9F1234567BCDEF12345678 /* ViewCode.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "ViewCode.swift"; sourceTree = "<group>"; };
 		EE9F1234567BCDEF12345678 /* CharacterCellViewModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CharacterCellViewModel.swift; sourceTree = "<group>"; };
 		1A8026D70B99D566B4C16C59 /* EpisodeRepository.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = EpisodeRepository.swift; sourceTree = "<group>"; };
 		1A821EC82862FE3C0024D397 /* APIClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIClient.swift; sourceTree = "<group>"; };
@@ -375,6 +377,7 @@
 			isa = PBXGroup;
 			children = (
 				BB9F1234567BCDEF12345678 /* UIFont+Adaptive.swift */,
+				FE9F1234567BCDEF12345678 /* ViewCode.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -724,6 +727,7 @@
 				81C6CDB86EAFB60DE88A63DC /* GetEpisodeRequest.swift in Sources */,
 				565172C41918A3AF9B8FFF82 /* DetailCharacterPresenter.swift in Sources */,
 				AA9F1234567BCDEF12345678 /* UIFont+Adaptive.swift in Sources */,
+				FF9F1234567BCDEF12345678 /* ViewCode.swift in Sources */,
 				DD9F1234567BCDEF12345678 /* CharacterCellViewModel.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/WallaMarvel/Presentation/Extensions/ViewCode.swift
+++ b/WallaMarvel/Presentation/Extensions/ViewCode.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+protocol ViewCode {
+    func setup()
+    func setupComponent()
+    func setupConstrain()
+    func setupExtraConfiguration()
+}
+
+extension ViewCode {
+    func setup() {
+        setupComponent()
+        setupConstrain()
+        setupExtraConfiguration()
+    }
+
+    func setupExtraConfiguration() {}
+}

--- a/WallaMarvel/Presentation/ListCharacter/ListCharactersTableView.swift
+++ b/WallaMarvel/Presentation/ListCharacter/ListCharactersTableView.swift
@@ -1,7 +1,7 @@
 import Foundation
 import UIKit
 
-final class ListCharactersView: UIView {
+final class ListCharactersView: UIView, ViewCode {
     private enum Constants {
         static let estimatedRowHeight: CGFloat = 120
         static let errorLabelHorizontalInset: CGFloat = 24
@@ -131,14 +131,10 @@ final class ListCharactersView: UIView {
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-    
-    private func setup() {
-        backgroundColor = .black
-        addSubviews()
-        addContraints()
-    }
-    
-    private func addSubviews() {
+
+    // MARK: - ViewCode
+
+    func setupComponent() {
         addSubview(charactersTableView)
         addSubview(errorContainerView)
         addSubview(emptySearchContainerView)
@@ -151,54 +147,9 @@ final class ListCharactersView: UIView {
         emptySearchContainerView.addSubview(emptySearchTitleLabel)
         emptySearchContainerView.addSubview(emptySearchMessageLabel)
     }
-    
-    private func addContraints() {
-        NSLayoutConstraint.activate([
-            charactersTableView.leadingAnchor.constraint(equalTo: leadingAnchor),
-            charactersTableView.trailingAnchor.constraint(equalTo: trailingAnchor),
-            charactersTableView.topAnchor.constraint(equalTo: topAnchor),
-            charactersTableView.bottomAnchor.constraint(equalTo: bottomAnchor),
-            
-            loadingView.leadingAnchor.constraint(equalTo: leadingAnchor),
-            loadingView.trailingAnchor.constraint(equalTo: trailingAnchor),
-            loadingView.topAnchor.constraint(equalTo: topAnchor),
-            loadingView.bottomAnchor.constraint(equalTo: bottomAnchor),
-            
-            loadingIndicator.centerXAnchor.constraint(equalTo: loadingView.centerXAnchor),
-            loadingIndicator.centerYAnchor.constraint(equalTo: loadingView.centerYAnchor),
-            
-            errorContainerView.leadingAnchor.constraint(equalTo: leadingAnchor),
-            errorContainerView.trailingAnchor.constraint(equalTo: trailingAnchor),
-            errorContainerView.topAnchor.constraint(equalTo: topAnchor),
-            errorContainerView.bottomAnchor.constraint(equalTo: bottomAnchor),
-            
-            errorLabel.leadingAnchor.constraint(equalTo: errorContainerView.leadingAnchor, constant: Constants.errorLabelHorizontalInset),
-            errorLabel.trailingAnchor.constraint(equalTo: errorContainerView.trailingAnchor, constant: -Constants.errorLabelHorizontalInset),
-            errorLabel.centerYAnchor.constraint(equalTo: errorContainerView.centerYAnchor, constant: Constants.errorLabelVerticalOffset),
-            
-            retryButton.topAnchor.constraint(equalTo: errorLabel.bottomAnchor, constant: Constants.retryButtonTopSpacing),
-            retryButton.centerXAnchor.constraint(equalTo: errorContainerView.centerXAnchor),
-            retryButton.widthAnchor.constraint(equalToConstant: Constants.retryButtonWidth),
-            retryButton.heightAnchor.constraint(equalToConstant: Constants.retryButtonHeight),
 
-            emptySearchContainerView.leadingAnchor.constraint(equalTo: leadingAnchor),
-            emptySearchContainerView.trailingAnchor.constraint(equalTo: trailingAnchor),
-            emptySearchContainerView.topAnchor.constraint(equalTo: topAnchor),
-            emptySearchContainerView.bottomAnchor.constraint(equalTo: bottomAnchor),
-
-            emptySearchIconView.centerXAnchor.constraint(equalTo: emptySearchContainerView.centerXAnchor),
-            emptySearchIconView.centerYAnchor.constraint(equalTo: emptySearchContainerView.centerYAnchor, constant: -Constants.emptySearchSpacing * 2),
-            emptySearchIconView.widthAnchor.constraint(equalToConstant: Constants.emptySearchIconSize),
-            emptySearchIconView.heightAnchor.constraint(equalToConstant: Constants.emptySearchIconSize),
-
-            emptySearchTitleLabel.topAnchor.constraint(equalTo: emptySearchIconView.bottomAnchor, constant: Constants.emptySearchSpacing),
-            emptySearchTitleLabel.leadingAnchor.constraint(equalTo: emptySearchContainerView.leadingAnchor, constant: Constants.emptySearchHorizontalInset),
-            emptySearchTitleLabel.trailingAnchor.constraint(equalTo: emptySearchContainerView.trailingAnchor, constant: -Constants.emptySearchHorizontalInset),
-
-            emptySearchMessageLabel.topAnchor.constraint(equalTo: emptySearchTitleLabel.bottomAnchor, constant: Constants.emptySearchSpacing / 2),
-            emptySearchMessageLabel.leadingAnchor.constraint(equalTo: emptySearchContainerView.leadingAnchor, constant: Constants.emptySearchHorizontalInset),
-            emptySearchMessageLabel.trailingAnchor.constraint(equalTo: emptySearchContainerView.trailingAnchor, constant: -Constants.emptySearchHorizontalInset),
-        ])
+    func setupExtraConfiguration() {
+        backgroundColor = .black
     }
 
     func configureTableView(delegate: UITableViewDelegate) -> ListCharactersAdapter {
@@ -255,5 +206,58 @@ final class ListCharactersView: UIView {
     func setRetryTarget(_ target: Any?, action: Selector) {
         retryButton.removeTarget(nil, action: nil, for: .allEvents)
         retryButton.addTarget(target, action: action, for: .touchUpInside)
+    }
+}
+
+// MARK: - ViewCode
+
+extension ListCharactersView {
+    func setupConstrain() {
+        NSLayoutConstraint.activate([
+            charactersTableView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            charactersTableView.trailingAnchor.constraint(equalTo: trailingAnchor),
+            charactersTableView.topAnchor.constraint(equalTo: topAnchor),
+            charactersTableView.bottomAnchor.constraint(equalTo: bottomAnchor),
+
+            loadingView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            loadingView.trailingAnchor.constraint(equalTo: trailingAnchor),
+            loadingView.topAnchor.constraint(equalTo: topAnchor),
+            loadingView.bottomAnchor.constraint(equalTo: bottomAnchor),
+
+            loadingIndicator.centerXAnchor.constraint(equalTo: loadingView.centerXAnchor),
+            loadingIndicator.centerYAnchor.constraint(equalTo: loadingView.centerYAnchor),
+
+            errorContainerView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            errorContainerView.trailingAnchor.constraint(equalTo: trailingAnchor),
+            errorContainerView.topAnchor.constraint(equalTo: topAnchor),
+            errorContainerView.bottomAnchor.constraint(equalTo: bottomAnchor),
+
+            errorLabel.leadingAnchor.constraint(equalTo: errorContainerView.leadingAnchor, constant: Constants.errorLabelHorizontalInset),
+            errorLabel.trailingAnchor.constraint(equalTo: errorContainerView.trailingAnchor, constant: -Constants.errorLabelHorizontalInset),
+            errorLabel.centerYAnchor.constraint(equalTo: errorContainerView.centerYAnchor, constant: Constants.errorLabelVerticalOffset),
+
+            retryButton.topAnchor.constraint(equalTo: errorLabel.bottomAnchor, constant: Constants.retryButtonTopSpacing),
+            retryButton.centerXAnchor.constraint(equalTo: errorContainerView.centerXAnchor),
+            retryButton.widthAnchor.constraint(equalToConstant: Constants.retryButtonWidth),
+            retryButton.heightAnchor.constraint(equalToConstant: Constants.retryButtonHeight),
+
+            emptySearchContainerView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            emptySearchContainerView.trailingAnchor.constraint(equalTo: trailingAnchor),
+            emptySearchContainerView.topAnchor.constraint(equalTo: topAnchor),
+            emptySearchContainerView.bottomAnchor.constraint(equalTo: bottomAnchor),
+
+            emptySearchIconView.centerXAnchor.constraint(equalTo: emptySearchContainerView.centerXAnchor),
+            emptySearchIconView.centerYAnchor.constraint(equalTo: emptySearchContainerView.centerYAnchor, constant: -Constants.emptySearchSpacing * 2),
+            emptySearchIconView.widthAnchor.constraint(equalToConstant: Constants.emptySearchIconSize),
+            emptySearchIconView.heightAnchor.constraint(equalToConstant: Constants.emptySearchIconSize),
+
+            emptySearchTitleLabel.topAnchor.constraint(equalTo: emptySearchIconView.bottomAnchor, constant: Constants.emptySearchSpacing),
+            emptySearchTitleLabel.leadingAnchor.constraint(equalTo: emptySearchContainerView.leadingAnchor, constant: Constants.emptySearchHorizontalInset),
+            emptySearchTitleLabel.trailingAnchor.constraint(equalTo: emptySearchContainerView.trailingAnchor, constant: -Constants.emptySearchHorizontalInset),
+
+            emptySearchMessageLabel.topAnchor.constraint(equalTo: emptySearchTitleLabel.bottomAnchor, constant: Constants.emptySearchSpacing / 2),
+            emptySearchMessageLabel.leadingAnchor.constraint(equalTo: emptySearchContainerView.leadingAnchor, constant: Constants.emptySearchHorizontalInset),
+            emptySearchMessageLabel.trailingAnchor.constraint(equalTo: emptySearchContainerView.trailingAnchor, constant: -Constants.emptySearchHorizontalInset),
+        ])
     }
 }

--- a/WallaMarvel/Presentation/ListCharacter/ListCharactersTableViewCell.swift
+++ b/WallaMarvel/Presentation/ListCharacter/ListCharactersTableViewCell.swift
@@ -2,7 +2,7 @@ import Foundation
 import UIKit
 import Kingfisher
 
-final class ListCharactersTableViewCell: UITableViewCell {
+final class ListCharactersTableViewCell: UITableViewCell, ViewCode {
 
     private enum Colors {
         static let card = UIColor(red: 11/255.0, green: 17/255.0, blue: 32/255.0, alpha: 1)
@@ -117,18 +117,18 @@ final class ListCharactersTableViewCell: UITableViewCell {
         fatalError("init(coder:) has not been implemented")
     }
 
-    // MARK: - Setup
+    // MARK: - ViewCode
 
-    private func setup() {
+    func setupComponent() {
+        contentView.addSubview(cardView)
+        cardView.addSubview(characterImageView)
+        cardView.addSubview(infoStack)
+    }
+
+    func setupExtraConfiguration() {
         backgroundColor = .clear
         contentView.backgroundColor = .clear
         selectionStyle = .none
-        addSubviews()
-        addConstraints()
-        setupAccessibility()
-    }
-
-    private func setupAccessibility() {
         isAccessibilityElement = true
         accessibilityHint = Strings.accessibilityHint
         characterImageView.isAccessibilityElement = false
@@ -137,13 +137,23 @@ final class ListCharactersTableViewCell: UITableViewCell {
         speciesLabel.isAccessibilityElement = false
     }
 
-    private func addSubviews() {
-        contentView.addSubview(cardView)
-        cardView.addSubview(characterImageView)
-        cardView.addSubview(infoStack)
-    }
+    // MARK: - Configure
 
-    private func addConstraints() {
+    func configure(viewModel: CharacterCellViewModel) {
+        let placeholder = UIImage(systemName: Strings.placeholderImage)
+        characterImageView.kf.setImage(with: viewModel.imageURL, placeholder: placeholder)
+        nameLabel.text = viewModel.name
+        speciesLabel.text = viewModel.species
+        statusDot.backgroundColor = viewModel.statusColor
+        statusLabel.text = viewModel.statusText
+        accessibilityLabel = "Character: \(viewModel.name). Status: \(viewModel.statusText). \(viewModel.species)."
+    }
+}
+
+// MARK: - ViewCode
+
+extension ListCharactersTableViewCell {
+    func setupConstrain() {
         NSLayoutConstraint.activate([
             cardView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: Constants.cardHorizontalInset),
             cardView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -Constants.cardHorizontalInset),
@@ -165,18 +175,6 @@ final class ListCharactersTableViewCell: UITableViewCell {
             infoStack.topAnchor.constraint(greaterThanOrEqualTo: cardView.topAnchor, constant: Constants.contentPadding),
             infoStack.bottomAnchor.constraint(lessThanOrEqualTo: cardView.bottomAnchor, constant: -Constants.contentPadding),
         ])
-    }
-
-    // MARK: - Configure
-
-    func configure(viewModel: CharacterCellViewModel) {
-        let placeholder = UIImage(systemName: Strings.placeholderImage)
-        characterImageView.kf.setImage(with: viewModel.imageURL, placeholder: placeholder)
-        nameLabel.text = viewModel.name
-        speciesLabel.text = viewModel.species
-        statusDot.backgroundColor = viewModel.statusColor
-        statusLabel.text = viewModel.statusText
-        accessibilityLabel = "Character: \(viewModel.name). Status: \(viewModel.statusText). \(viewModel.species)."
     }
 }
 


### PR DESCRIPTION
## Summary

- `ViewCode` protocol applied to `ListCharactersView` and `ListCharactersTableViewCell`
- `setupConstrain()` extracted from the class body into a dedicated `extension` block at the bottom of each file

---

## Context

- The `ViewCode` protocol (`setup()` → `setupComponent()` → `setupConstrain()` → `setupExtraConfiguration()`) was already in place from WP-19
- Keeping constraints inside the class body mixes layout concerns with class structure; moving them into an extension follows the same separation-of-concerns pattern used throughout the project (e.g. `UITableViewDelegate`, `UISearchResultsUpdating` conformances are already in extensions in `ListCharactersViewController`)

---

## Changes

- `ListCharactersTableView.swift`:
  - Removed `setupConstrain()` from the class body
  - Added `// MARK: - ViewCode` + `extension ListCharactersView { func setupConstrain() { ... } }` at the bottom of the file
- `ListCharactersTableViewCell.swift`:
  - Removed `setupConstrain()` from the class body
  - Added `// MARK: - ViewCode` + `extension ListCharactersTableViewCell { func setupConstrain() { ... } }` at the bottom of the file

---

## Notes

- No logic changes — pure structural refactor
- `setupComponent()` and `setupExtraConfiguration()` remain in the class body; only layout constraints are moved
- No Domain or Data layer changes
- No new tests required — existing tests remain green